### PR TITLE
Check FASTQ fields 1 and 3

### DIFF
--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
@@ -33,8 +33,12 @@ final class FastqParser(file: Path) extends CloseableIterable[Read] {
       val line2 = nextLine()
       val line3 = nextLine()
 
-      if (line0.charAt(0) != '@') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 1 must begin with '@'") }
-      if (line2.charAt(0) != '+') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 3 must begin with '+'") }
+      if (line0.charAt(0) != '@') {
+        throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 1 must begin with '@'")
+      }
+      if (line2.charAt(0) != '+') {
+        throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 3 must begin with '+'")
+      }
 
       if (line3 == null) throw InvalidFileException(file, "File contains an incomplete FASTQ read")
       else Read(line0, line1)

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
@@ -25,16 +25,19 @@ final class FastqParser(file: Path) extends CloseableIterable[Read] {
       ret
     }
 
+    // for details on the FASTQ format, see https://maq.sourceforge.net/fastq.shtml
     final override def next(): Read = {
       // get the next record and make sure it's complete
       val line0 = nextLine()
       val line1 = nextLine()
-      nextLine()
+      val line2 = nextLine()
       val line3 = nextLine()
 
-      if (line3 == null) {
-        throw InvalidFileException(file, "File contains an incomplete FASTQ read")
-      } else Read(line0, line1)
+      if (line0.charAt(0) != '@') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ") }
+      if (line2.charAt(0) != '+') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ") }
+
+      if (line3 == null) throw InvalidFileException(file, "File contains an incomplete FASTQ read")
+      else Read(line0, line1)
     }
 
     final override def hasNext: Boolean = line != null

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
@@ -33,8 +33,8 @@ final class FastqParser(file: Path) extends CloseableIterable[Read] {
       val line2 = nextLine()
       val line3 = nextLine()
 
-      if (line0.charAt(0) != '@') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ") }
-      if (line2.charAt(0) != '+') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ") }
+      if (line0.charAt(0) != '@') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 1 must begin with '@'") }
+      if (line2.charAt(0) != '+') { throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 3 must begin with '+'") }
 
       if (line3 == null) throw InvalidFileException(file, "File contains an incomplete FASTQ read")
       else Read(line0, line1)

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
@@ -33,6 +33,26 @@ class FastqParserTest extends AnyFlatSpec {
     }
   }
 
+  "FastqParser" should "reject a misaligned FASTQ file" in {
+    val data =
+      """+
+        |4<<8-767
+        |@HWUSI-EAS100R:6:23:398:3989#1
+        |AACTCACG
+        |+""".stripMargin
+
+    val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
+    try {
+      file.overwrite(data)
+      val fqp = new FastqParser(file.path)
+      intercept[InvalidFileException] {
+        fqp.toList
+      }
+    } finally {
+      file.delete()
+    }
+  }
+
   it should "parse complete records" in {
     val data =
       """@HWUSI-EAS100R:6:23:398:3989#1


### PR DESCRIPTION
According to the spec, field 1 must begin with `@` and field 3 must
begin with `+`. Checking for these helps prevent users from accidentally
deconvoluting files that have been corrupted or improperly concatenated.