### PR TITLE
Parse barcodes from read IDs in demultiplexed mode

### DIFF
--- a/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQ.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQ.scala
@@ -116,8 +116,10 @@ object PoolQ {
       ExactReference(referenceData.mappings, identity, includeAmbiguous = false)
     }
 
+    val colBarcodePolicyOrLength: Either[Int, BarcodePolicy] = colBarcodePolicyOpt.toRight(colReference.barcodeLength)
+
     val barcodes: CloseableIterable[Barcodes] =
-      barcodeSource(config.input, rowBarcodePolicy, revRowBarcodePolicyOpt, colBarcodePolicyOpt, umiInfo.map(_._2))
+      barcodeSource(config.input, rowBarcodePolicy, revRowBarcodePolicyOpt, colBarcodePolicyOrLength, umiInfo.map(_._2))
 
     lazy val unexpectedSequenceCacheDir: Option[Path] =
       if (config.skipUnexpectedSequenceReport) None

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQConfig.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQConfig.scala
@@ -107,7 +107,10 @@ final case class PoolQConfig(
       (input.readsSourceE match {
         case Right(ReadsSource.PairedEnd(_, _, _))    => true
         case Right(ReadsSource.DmuxedPairedEnd(_, _)) => true
-        case _                                        => false
+        case Right(ReadsSource.SelfContained(_))      => false
+        case Right(ReadsSource.Split(_, _))           => false
+        case Right(ReadsSource.Dmuxed(_))             => false
+        case Left(_)                                  => false
       })
 
 }

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQConfig.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQConfig.scala
@@ -105,8 +105,9 @@ final case class PoolQConfig(
   def isPairedEnd =
     reverseRowBarcodePolicyStr.isDefined &&
       (input.readsSourceE match {
-        case Right(ReadsSource.PairedEnd(_, _, _)) => true
-        case _                                     => false
+        case Right(ReadsSource.PairedEnd(_, _, _))    => true
+        case Right(ReadsSource.DmuxedPairedEnd(_, _)) => true
+        case _                                        => false
       })
 
 }

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/barcode/Dmuxed.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/barcode/Dmuxed.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 The Broad Institute, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.broadinstitute.gpp.poolq3.barcode
+
+object Dmuxed {
+
+  private[barcode] def barcodeFromId(length: Int): String => Option[FoundBarcode] = {
+    val regex = s"@.*[^ACGTN]([ACGTN]{$length})$$".r
+    _ match {
+      case regex(barcode) => Some(FoundBarcode(barcode.toCharArray, 0))
+      case _              => None
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/CloseableIterable.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/CloseableIterable.scala
@@ -50,8 +50,11 @@ object DmuxedIterable {
     val data2: List[(Option[String], List[Read])] = data.map { case (bco, seqs) =>
       (bco, seqs.zipWithIndex.map { case (seq, i) => Read(i.toString, seq) })
     }
-    new DmuxedIterableImpl(data2, CloseableIterator.ofList)
+    DmuxedIterable.forReads(data2)
   }
+
+  def forReads(data: List[(Option[String], List[Read])]): DmuxedIterable =
+    new DmuxedIterableImpl(data, CloseableIterator.ofList)
 
   private class DmuxedIterableImpl[A](src: Iterable[(Option[String], A)], makeIterator: A => CloseableIterator[Read])
       extends DmuxedIterable {

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/DmuxedTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/DmuxedTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The Broad Institute, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.broadinstitute.gpp.poolq3.barcode
+
+import munit.FunSuite
+
+class DmuxedTest extends FunSuite {
+
+  test("extracting a barcode with Ns from an illumina read") {
+    assertEquals(
+      Dmuxed.barcodeFromId(8)("@A01379:680:HC37HDRX3:1:2101:1163:1000 1:N:0:GGNGNANT"),
+      Some(FoundBarcode("GGNGNANT".toCharArray, 0))
+    )
+  }
+
+  test("extracting a barcode with no Ns from an illumina read") {
+    assertEquals(
+      Dmuxed.barcodeFromId(8)("@A01379:680:HC37HDRX3:1:2101:3224:1000 1:N:0:AAATGCGA"),
+      Some(FoundBarcode("AAATGCGA".toCharArray, 0))
+    )
+  }
+
+  test("ignore a barcode-like sequence that's too long") {
+    assertEquals(Dmuxed.barcodeFromId(8)("@A01379:680:HC37HDRX3:1:2101:3224:1000 1:N:0:AAATGCGAGG"), None)
+  }
+
+  test("ignore a barcode-like sequence that's too short") {
+    assertEquals(Dmuxed.barcodeFromId(8)("@A01379:680:HC37HDRX3:1:2101:3224:1000 1:N:0:TGCGAGG"), None)
+  }
+
+}


### PR DESCRIPTION
If a file has no barcodes associated, attempt to parse a barcode from the read IDs.