### PR TITLE
Unexpected sequence improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.13.2
+
+### Improvements
+
+* Reduce memory overhead for the unexpected sequence
+* In the logs, report read counts using the default locale for formatting
+
 ## 3.13.1
 
 ### Bugfixes

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -2,7 +2,7 @@
 
 PoolQ is a counter for indexed samples from next-gen sequencing of pooled DNA.
 
-_This documentation covers PoolQ version 3.13.3 (last updated 10/14/2025)._
+_This documentation covers PoolQ version 3.13.2 (last updated 12/2/2025)._
 
 ## Background
 
@@ -571,7 +571,7 @@ PoolQ you will need a Java 11 JDK. You can download an appropriate JRE or JDK fr
 You can download PoolQ from an as yet undetermined location. The file you download is a ZIP file
 that you will need to unzip. In most cases, this is as simple as right-clicking on the zip file, and
 selecting something like "extract contents" from the popup menu. This will create a new folder on
-your computer named `poolq-3.13.0`, with the following contents:
+your computer named `poolq-3.13.2`, with the following contents:
 
 - `poolq3.jar`
 - `poolq3.bat`
@@ -622,7 +622,7 @@ You can run PoolQ from any Windows, Mac, or Linux machine, but it requires some 
 how to launch programs from the command line on your given operating system.
 
 1. Open a terminal window for your operating system
-2. Change directories to the `poolq-3.13.0` directory
+2. Change directories to the `poolq-3.13.2` directory
 
 - On Windows, run:
 
@@ -639,7 +639,7 @@ how to launch programs from the command line on your given operating system.
 If you successfully launched PoolQ, you should see a usage message explaining all of the
 command-line options:
 
-    poolq3 3.13.0
+    poolq3 3.13.2
     Usage: poolq [options]
 
       --row-reference <file>   reference file for row barcodes (i.e., constructs)

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/process/PoolQProcess.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/process/PoolQProcess.scala
@@ -5,6 +5,8 @@
  */
 package org.broadinstitute.gpp.poolq3.process
 
+import java.text.NumberFormat
+import java.util.Locale
 import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
 
 import scala.util.control.NonFatal
@@ -27,6 +29,8 @@ final class PoolQProcess(
 
   private val log: Logger = getLogger
 
+  private val nf: NumberFormat = NumberFormat.getInstance(Locale.getDefault())
+
   private val queue: ArrayBlockingQueue[Barcodes] = new ArrayBlockingQueue(queueSize)
 
   @volatile private var done = false
@@ -41,14 +45,17 @@ final class PoolQProcess(
         val dt = System.currentTimeMillis() - t0
         val avg = nd / dt
         val pct = consumer.matchPercent
-        log.info(s"Processed $n reads in $dt ms ($avg reads/ms). Match percent: $pct; queue size: ${queue.size()}")
+        log.info(
+          s"Processed ${nf.format(n)} reads in $dt ms ($avg reads/ms). Match percent: $pct; queue size: ${queue.size()}"
+        )
+      end logProgress
 
       while !done || !queue.isEmpty do // as long as we're not done OR there is still work in the queue
         try Option(queue.poll(100, TimeUnit.MILLISECONDS)).foreach(next => consumer.consume(next))
         catch
           case _: InterruptedException =>
             log.warn(
-              s"Interrupted. Done = $done Processed ${consumer.readsProcessed} reads; queue has ${queue.size()} remaining"
+              s"Interrupted. Done = $done Processed ${nf.format(consumer.readsProcessed)} reads; queue has ${queue.size()} remaining"
             )
           case NonFatal(e) => log.error(e)(s"Error processing read ${consumer.readsProcessed}")
         // update the log periodically

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -126,7 +126,12 @@ object UnexpectedSequenceWriter:
       }
 
       // find the most popular N row barcodes
-      val mostCommonRowBarcodesRanked = allRowBarcodeCounts.toVector.sortBy(-_._2).take(nSequencesToReport).map(_._1)
+      val stringOrd: Ordering[String] = Ordering[String]
+      val mostCommonRowBarcodesRanked =
+        // make an ordering that prioritizes high numbers and lexicographically earlier barcodes
+        given Ordering[String] = stringOrd.reverse
+        topNBy(allRowBarcodeCounts, nSequencesToReport, (x, y) => (y, x), Ordering[(Int, String)]).map(_._2)
+
       val mostCommonRowBarcodes = mostCommonRowBarcodesRanked.toSet
 
       // filter out everything else and convert to an immutable map

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -16,6 +16,8 @@ import scala.util.{Try, Using}
 import org.broadinstitute.gpp.poolq3.process.UnexpectedSequenceTracker.nameFor
 import org.broadinstitute.gpp.poolq3.reference.Reference
 import org.log4s.{Logger, getLogger}
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.Queue
 
 object UnexpectedSequenceWriter:
 
@@ -79,10 +81,9 @@ object UnexpectedSequenceWriter:
       maxMapSize: Int
   ): (Map[String, Map[String, Int]], Vector[String]) =
     val rowColBarcodeCounts = new mutable.HashMap[String, mutable.Map[String, Int]]()
-    val allRowBarcodeCounts = new mutable.HashMap[String, Int]()
 
     // create & populate the list of readers
-    val readers = mutable.Queue[CachedBarcodes]()
+    val readers: Queue[CachedBarcodes] = mutable.Queue()
     try
       colReference.allBarcodes.foreach { colBc =>
         val file = cacheDir.resolve(nameFor(colBc))
@@ -100,10 +101,6 @@ object UnexpectedSequenceWriter:
           case None => Some(1)
           case Some(c) => Some(c + 1)
         }
-        val _ = allRowBarcodeCounts.updateWith(rowBc) {
-          case None => Some(1)
-          case Some(c) => Some(c + 1)
-        }
       end while
       // at this point, we either exhausted the readers or we filled the map; go through the remaining data
       // and tally things up, but don't add new keys to the outer map
@@ -113,10 +110,6 @@ object UnexpectedSequenceWriter:
           // in the set of things we're keeping track of
           rowColBarcodeCounts.get(rowBc).foreach { colBarcodeMap =>
             val _ = colBarcodeMap.updateWith(rdr.colBc) {
-              case None => Some(1)
-              case Some(c) => Some(c + 1)
-            }
-            val _ = allRowBarcodeCounts.updateWith(rowBc) {
               case None => Some(1)
               case Some(c) => Some(c + 1)
             }
@@ -130,7 +123,13 @@ object UnexpectedSequenceWriter:
       val mostCommonRowBarcodesRanked =
         // make an ordering that prioritizes high numbers and lexicographically earlier barcodes
         given Ordering[String] = stringOrd.reverse
-        topNBy(allRowBarcodeCounts, nSequencesToReport, (x, y) => (y, x), Ordering[(Int, String)]).map(_._2)
+        topNBy(
+          rowColBarcodeCounts,
+          nSequencesToReport,
+          (rowBc, perColCounts) => (perColCounts.values.sum, rowBc),
+          Ordering[(Int, String)]
+        ).map(_._2)
+      end mostCommonRowBarcodesRanked
 
       val mostCommonRowBarcodes = mostCommonRowBarcodesRanked.toSet
 

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -16,8 +16,6 @@ import scala.util.{Try, Using}
 import org.broadinstitute.gpp.poolq3.process.UnexpectedSequenceTracker.nameFor
 import org.broadinstitute.gpp.poolq3.reference.Reference
 import org.log4s.{Logger, getLogger}
-import scala.collection.mutable.HashMap
-import scala.collection.mutable.Queue
 
 object UnexpectedSequenceWriter:
 
@@ -83,7 +81,7 @@ object UnexpectedSequenceWriter:
     val rowColBarcodeCounts = new mutable.HashMap[String, mutable.Map[String, Int]]()
 
     // create & populate the list of readers
-    val readers: Queue[CachedBarcodes] = mutable.Queue()
+    val readers: mutable.Queue[CachedBarcodes] = mutable.Queue()
     try
       colReference.allBarcodes.foreach { colBc =>
         val file = cacheDir.resolve(nameFor(colBc))

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -144,6 +144,20 @@ object UnexpectedSequenceWriter:
 
   end loadCache
 
+  private[reports] def topNBy[A, B](xs: Iterable[A], n: Int, f: A => B, ord: Ordering[B]): Vector[B] =
+    given Ordering[B] = ord.reverse
+    val pq: mutable.PriorityQueue[B] = new mutable.PriorityQueue
+    xs.foreach { x =>
+      pq.addOne(f(x))
+      if pq.size > n then
+        val _ = pq.dequeue()
+    }
+    val ret: Vector[B] = pq.toVector
+    assert(ret.size <= n)
+    ret.reverse
+
+  end topNBy
+
   private[reports] def printUnexpectedCounts(
       colReference: Reference,
       globalReferenceOpt: Option[Reference],

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -108,12 +108,11 @@ object UnexpectedSequenceWriter:
       // at this point, we either exhausted the readers or we filled the map; go through the remaining data
       // and tally things up, but don't add new keys to the outer map
       readers.foreach { rdr =>
-        val colBc = rdr.colBc
         rdr.foreach { rowBc =>
           // now, we only update if there was an existing entry in `rowColBarcodeCounts` because it means it's
           // in the set of things we're keeping track of
           rowColBarcodeCounts.get(rowBc).foreach { colBarcodeMap =>
-            val _ = colBarcodeMap.updateWith(colBc) {
+            val _ = colBarcodeMap.updateWith(rdr.colBc) {
               case None => Some(1)
               case Some(c) => Some(c + 1)
             }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/TestResources.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/TestResources.scala
@@ -10,12 +10,12 @@ import java.nio.file.{Path, Paths}
 trait TestResources:
 
   def resourcePath(clazz: Class[?], name: String): Path =
-    val r = clazz.getResource(name)
+    val r = clazz.getResource(name).toURI()
     require(r != null, s"Can't find resource at path $name for ${getClass.getName}")
     Paths.get(r.getPath)
 
   def resourcePath(name: String): Path =
-    val r = this.getClass.getResource(name)
+    val r = this.getClass.getResource(name).toURI()
     require(r != null, s"Can't find resource at path $name for ${getClass.getName}")
     Paths.get(r.getPath)
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequencesTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequencesTest.scala
@@ -235,4 +235,24 @@ class UnexpectedSequencesTest extends FunSuite with TestResources:
 
   end testIt
 
+  test("topNBy") {
+    val counts: Map[String, Int] =
+      Map(
+        "ACA" -> 983,
+        "GTC" -> 839,
+        "TCA" -> 392,
+        "ACT" -> 389,
+        "GAC" -> 293,
+        "TAG" -> 180,
+        "AAA" -> 100,
+        "AGT" -> 93,
+        "CCA" -> 29,
+        "GTA" -> 2
+      )
+    assertEquals(
+      UnexpectedSequenceWriter.topNBy(counts, 4, (x, y) => (y, x), Ordering[(Int, String)]),
+      Vector("ACA" -> 983, "GTC" -> 839, "TCA" -> 392, "ACT" -> 389).map(_.swap)
+    )
+  }
+
 end UnexpectedSequencesTest


### PR DESCRIPTION
The unexpected sequence report generation is theoretically memory bounded. It reads a fixed `k` unexpected sequences from its cache to make a set of unexpected sequences for which it tracks exact counts as it processes the balance of the cache. This limits the data structures used for the balance of the processing to size `k`, enabling the report processing to use constant memory.

Unfortunately, in the previous implementation, for convenience, we ended up making several data structures, each of which contained the set of `k` barcode counts in various forms, meaning that despite the constant memory bound, we ended up with a fairly high constant.

This PR attempts to optimize the memory usage slightly, in 2 phases.

In the first phase, we replace the "sort and take `n`" strategy with an implementation of `topN` using a bounded priority queue. This eliminates the effort of copying and then sorting an entire vector of the set, only to discard the vast majority of them.

In the second phase, we rework our use of the `topN` function so that we remove yet another copy of the set kept in memory.

This PR includes a few other minor improvements, including a minor patch to the test resources trait and and a human-readability fix to the poolq logs.