### PR TITLE
Minor fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,6 @@ lazy val versions = new {
   val samTools = "3.0.5"
   val scalaCheck = "1.19.0"
   val scalaCsv = "2.0.0"
-  val scalaTest = "3.2.20"
-  val scalaTestPlusScalaCheck = "3.2.18.0"
   val scopt = "4.1.0"
   val slf4j = "2.0.17"
 }
@@ -54,9 +52,7 @@ lazy val libraries = new {
   val munit = "org.scalameta" %% "munit" % versions.munit
   val munitScalacheck = "org.scalameta" %% "munit-scalacheck" % versions.munitScalaCheck
   val munitCatsEffect = "org.typelevel" %% "munit-cats-effect" % versions.munitCatsEffect3
-  val scalaTest = "org.scalatest" %% "scalatest" % versions.scalaTest
   val scalaCheck = "org.scalacheck" %% "scalacheck" % versions.scalaCheck
-  val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-17" % versions.scalaTestPlusScalaCheck
 }
 
 lazy val dependencies =
@@ -80,9 +76,7 @@ lazy val dependencies =
     libraries.munit % Test,
     libraries.munitCatsEffect % Test,
     libraries.munitScalacheck % Test,
-    libraries.scalaCheck % Test,
-    libraries.scalaTest % Test,
-    libraries.scalaTestPlusScalaCheck % Test
+    libraries.scalaCheck % Test
   )
 
 lazy val headerLicenseText =

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQ.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/PoolQ.scala
@@ -205,7 +205,7 @@ object PoolQ:
           UnexpectedSequenceWriter.removeCache(dir)
         ret
       }
-      _ = log.info(s"Writing run info ${config.output.unexpectedSequencesFile}")
+      _ = log.info(s"Writing run info ${config.output.runInfoFile}")
       _ <- RunInfoWriter.write(config.output.runInfoFile, config)
       _ = log.info("PoolQ complete")
     yield PoolQSummary(runSummary, AlwaysWrittenFiles ++ Set(cfto, usfto).flatten)

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
@@ -34,9 +34,9 @@ final class FastqParser(file: Path) extends CloseableIterable[Read]:
 
       if line3 == null then throw InvalidFileException(file, "File contains an incomplete FASTQ read")
 
-      if line0.charAt(0) != '@' then
+      if line0 != null && line0.charAt(0) != '@' then
         throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 1 must begin with '@'")
-      if line2.charAt(0) != '+' then
+      if line2 != null && line2.charAt(0) != '+' then
         throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 3 must begin with '+'")
 
       Read(line0, line1)

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/parser/FastqParser.scala
@@ -32,13 +32,14 @@ final class FastqParser(file: Path) extends CloseableIterable[Read]:
       val line2 = nextLine()
       val line3 = nextLine()
 
+      if line3 == null then throw InvalidFileException(file, "File contains an incomplete FASTQ read")
+
       if line0.charAt(0) != '@' then
         throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 1 must begin with '@'")
       if line2.charAt(0) != '+' then
         throw InvalidFileException(file, "Corrupt or incorrect FASTQ: field 3 must begin with '+'")
 
-      if line3 == null then throw InvalidFileException(file, "File contains an incomplete FASTQ read")
-      else Read(line0, line1)
+      Read(line0, line1)
 
     end next
 

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/process/Constants.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/process/Constants.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 The Broad Institute, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.broadinstitute.gpp.poolq3.process
+
+object Constants:
+
+  // the amount of time we're willing to wait on a queue offer or take before checking for an exception
+  // we care more about throughput than latency so we don't need to check that aggressively
+  val QueueTimeoutMillis: Long = 250L

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/process/PoolQProcess.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/process/PoolQProcess.scala
@@ -33,7 +33,11 @@ final class PoolQProcess(
 
   private val queue: ArrayBlockingQueue[Barcodes] = new ArrayBlockingQueue(queueSize)
 
+  private val queueWaitMillis: Long = 100L
+
   @volatile private var done = false
+
+  @volatile private var consumerFailure: Throwable | Null = null
 
   final private class ConsumerThread extends Thread:
 
@@ -50,14 +54,18 @@ final class PoolQProcess(
         )
       end logProgress
 
-      while !done || !queue.isEmpty do // as long as we're not done OR there is still work in the queue
+      while consumerFailure == null && (!done || !queue.isEmpty) do
         try Option(queue.poll(100, TimeUnit.MILLISECONDS)).foreach(next => consumer.consume(next))
         catch
           case _: InterruptedException =>
             log.warn(
               s"Interrupted. Done = $done Processed ${nf.format(consumer.readsProcessed)} reads; queue has ${queue.size()} remaining"
             )
-          case NonFatal(e) => log.error(e)(s"Error processing read ${consumer.readsProcessed}")
+          case NonFatal(e) =>
+            consumerFailure = e
+            done = true
+            log.error(e)(s"Error processing read ${consumer.readsProcessed}; terminating run")
+        end try
         // update the log periodically
         val n = consumer.readsProcessed
         if n % reportFrequency == 0L then logProgress(n)
@@ -72,24 +80,59 @@ final class PoolQProcess(
   def run(): PoolQRunSummary =
     val consumerThread = new ConsumerThread
     consumerThread.setName("Consumer")
+    var consumerClosed = false
+
+    def closeConsumer(primaryErrorOpt: Option[Throwable]): Unit =
+      if !consumerClosed then
+        try
+          consumer.close()
+          consumerClosed = true
+        catch
+          case NonFatal(closeErr) =>
+            primaryErrorOpt match
+              case Some(primaryError) => primaryError.addSuppressed(closeErr)
+              case None => throw closeErr
+      end if
+    end closeConsumer
+
+    // Keep retrying until an item is successfully enqueued, but fail fast if the consumer has errored.
+    def enqueueOrFail(next: Barcodes): Unit =
+      var enqueued = false
+      while !enqueued do
+        val failure = consumerFailure
+        if failure != null then throw failure
+        enqueued = queue.offer(next, queueWaitMillis, TimeUnit.MILLISECONDS)
 
     log.info("Beginning task processing.")
     consumer.start()
     consumerThread.start()
 
-    // fill the queue
-    source.foreach(queue.put)
+    try
+      // fill the queue while checking for failures in the consumer thread
+      while source.hasNext && consumerFailure == null do
+        val next = source.next()
+        enqueueOrFail(next)
 
-    // signal the end
-    done = true
+      // signal the end
+      done = true
 
-    // shut down the processing thread
-    log.info("Shutting down.")
-    consumerThread.join()
+      // shut down the processing thread
+      log.info("Shutting down.")
+      consumerThread.join()
 
-    consumer.close()
+      val failure = Option(consumerFailure)
+      closeConsumer(failure)
+      failure.foreach(throw _)
 
-    PoolQRunSummary(consumer.readsProcessed, consumer.matchingReads, consumer.matchPercent, consumer.state)
+      PoolQRunSummary(consumer.readsProcessed, consumer.matchingReads, consumer.matchPercent, consumer.state)
+    catch
+      case t: Throwable =>
+        done = true
+        consumerThread.interrupt()
+        consumerThread.join()
+        closeConsumer(Some(t))
+        throw t
+    end try
 
   end run
 

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/process/ScoringConsumer.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/process/ScoringConsumer.scala
@@ -28,8 +28,6 @@ final class ScoringConsumer(
 
   private val log: Logger = getLogger
 
-  private val pollTimeoutMillis: Long = 100L
-
   private val unexpectedSequenceQueue: ArrayBlockingQueue[(Array[Char], Array[Char])] =
     new ArrayBlockingQueue(1000)
 
@@ -59,7 +57,7 @@ final class ScoringConsumer(
 
       while threadError == null && !unexpectedTrackerDone do
         try
-          Option(unexpectedSequenceQueue.poll(pollTimeoutMillis, TimeUnit.MILLISECONDS))
+          Option(unexpectedSequenceQueue.poll(Constants.QueueTimeoutMillis, TimeUnit.MILLISECONDS))
             .foreach(unexpectedSequenceTracker.reportUnexpected)
         catch
           case _: InterruptedException =>
@@ -206,8 +204,17 @@ final class ScoringConsumer(
     if row.isEmpty && revRow.isEmpty then state.neitherRowBarcodeFound += 1L
 
   private def enqueueUnexpected(rowBarcode: Array[Char], columnBarcode: Array[Char]): Unit =
-    failOnThreadError()
-    unexpectedSequenceQueue.put((rowBarcode, columnBarcode))
+    val entry = (rowBarcode, columnBarcode)
+    var enqueued = false
+    while !enqueued do
+      failOnThreadError()
+      try enqueued = unexpectedSequenceQueue.offer(entry, Constants.QueueTimeoutMillis, TimeUnit.MILLISECONDS)
+      catch
+        case e: InterruptedException =>
+          Thread.currentThread().interrupt()
+          throw new IllegalStateException("Interrupted while enqueueing unexpected sequence.", e)
+
+  end enqueueUnexpected
 
   private def failOnThreadError(): Unit =
     val err = threadError

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/process/ScoringConsumer.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/process/ScoringConsumer.scala
@@ -7,6 +7,8 @@ package org.broadinstitute.gpp.poolq3.process
 
 import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
 
+import scala.util.control.NonFatal
+
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.hist.{BasicShardedHistogram, OpenHashMapHistogram, TupleHistogram}
 import org.broadinstitute.gpp.poolq3.parser.BarcodeSet
@@ -26,11 +28,17 @@ final class ScoringConsumer(
 
   private val log: Logger = getLogger
 
+  private val pollTimeoutMillis: Long = 100L
+
   private val unexpectedSequenceQueue: ArrayBlockingQueue[(Array[Char], Array[Char])] =
     new ArrayBlockingQueue(1000)
 
   // used to tell the unexpected sequence tracker thread when processing is done
-  @volatile private var done = false
+  @volatile private var inputProcessingDone = false
+
+  // stores any error that occurs in a thread running within this consumer; currently the only one of those
+  // is the unexpected sequence tracker thread
+  @volatile private var threadError: Throwable | Null = null
 
   // tracks the state as we go
   override val state =
@@ -47,13 +55,19 @@ final class ScoringConsumer(
     final override def run(): Unit =
       assert(unexpectedSequenceTrackerOpt.isDefined)
       val unexpectedSequenceTracker = unexpectedSequenceTrackerOpt.get
-      while !done || !unexpectedSequenceQueue.isEmpty do
+      def unexpectedTrackerDone: Boolean = inputProcessingDone && unexpectedSequenceQueue.isEmpty
+
+      while threadError == null && !unexpectedTrackerDone do
         try
-          Option(unexpectedSequenceQueue.poll(100, TimeUnit.MILLISECONDS))
+          Option(unexpectedSequenceQueue.poll(pollTimeoutMillis, TimeUnit.MILLISECONDS))
             .foreach(unexpectedSequenceTracker.reportUnexpected)
         catch
           case _: InterruptedException =>
-            log.debug(s"Interrupted. Done = $done; queue length = ${unexpectedSequenceQueue.size()}")
+            log.debug(s"Interrupted. Done = $inputProcessingDone; queue length = ${unexpectedSequenceQueue.size()}")
+          case NonFatal(e) =>
+            threadError = e
+            log.error(e)("Unexpected sequence tracker failed")
+      end while
 
     end run
 
@@ -62,12 +76,15 @@ final class ScoringConsumer(
 
   override def close(): Unit =
     unexpectedSequenceTrackerOpt.foreach { _ =>
-      done = true
+      inputProcessingDone = true
       unexpectedSequenceTrackerThread.join()
       unexpectedSequenceTrackerOpt.foreach(_.close())
+      failOnThreadError()
     }
 
   override def consume(parsedBarcode: Barcodes): Unit =
+    failOnThreadError()
+
     // increment the read counter regardless
     state.reads += 1
 
@@ -96,7 +113,7 @@ final class ScoringConsumer(
           // match the row barcode to the reference data, and the row barcode doesn't have an N in it, then queue the
           // row barcode for inclusion in the unexpected sequence report
           if unexpectedSequenceTrackerOpt.isDefined && colBc.nonEmpty && rowBc.isEmpty && !containsN(parsedRow.barcode)
-          then unexpectedSequenceQueue.put((parsedRow.barcode, parsedCol.barcode))
+          then enqueueUnexpected(parsedRow.barcode, parsedCol.barcode)
         end if
 
       case (f @ Some(parsedRow), r @ Some(parsedRevRow), Some(parsedCol)) =>
@@ -120,7 +137,7 @@ final class ScoringConsumer(
         // match the row barcode to the reference data, and the row barcode doesn't have an N in it, then queue the
         // row barcode for inclusion in the unexpected sequence report
         if unexpectedSequenceTrackerOpt.isDefined && colBc.nonEmpty && rowBc.isEmpty && !containsN(combinedBarcode)
-        then unexpectedSequenceQueue.put((combinedBarcode, parsedCol.barcode))
+        then enqueueUnexpected(combinedBarcode, parsedCol.barcode)
 
       case (None, r, None) =>
         updateRowBarcodePositionStats(None, r)
@@ -187,6 +204,14 @@ final class ScoringConsumer(
     row.foreach(r => state.rowBarcodeStats.update(r.offset0))
     revRow.foreach(r => state.revRowBarcodeStats.update(r.offset0))
     if row.isEmpty && revRow.isEmpty then state.neitherRowBarcodeFound += 1L
+
+  private def enqueueUnexpected(rowBarcode: Array[Char], columnBarcode: Array[Char]): Unit =
+    failOnThreadError()
+    unexpectedSequenceQueue.put((rowBarcode, columnBarcode))
+
+  private def failOnThreadError(): Unit =
+    val err = threadError
+    if threadError != null then throw IllegalStateException("Unexpected sequence tracker failed.", err)
 
   override def readsProcessed: Long = state.reads
 

--- a/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
+++ b/src/main/scala/org/broadinstitute/gpp/poolq3/reports/UnexpectedSequenceWriter.scala
@@ -44,7 +44,7 @@ object UnexpectedSequenceWriter:
       catch case NonFatal(_) => log.warn(s"Unable to delete ${p.toAbsolutePath}")
 
     // run for side effects
-    Files.list(unexpectedSequenceCacheDir).forEach(tryDelete)
+    Using.resource(Files.list(unexpectedSequenceCacheDir))(paths => paths.forEach(tryDelete))
     tryDelete(unexpectedSequenceCacheDir)
 
   end removeCache

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/FixedOffsetPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/FixedOffsetPolicyTest.scala
@@ -5,35 +5,40 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgtn, dnaSeq}
 import org.broadinstitute.gpp.poolq3.types.Read
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
 
-class FixedOffsetPolicyTest extends AnyFlatSpec:
+class FixedOffsetPolicyTest extends FunSuite with ScalaCheckSuite:
 
-  "find" should "find the barcode in the read" in {
+  test("find should find the barcode in the read") {
     forAll(dnaSeq(acgtn), dnaSeq(acgtn), dnaSeq(acgtn)) { (a: String, b: String, c: String) =>
       val read = Read("id", a + b + c)
       val policy = FixedOffsetPolicy(a.length, b.length, skipShortReads = false)
-      policy.find(read) should contain(FoundBarcode(b.toCharArray, a.length))
+      assertEquals(policy.find(read), Some(FoundBarcode(b.toCharArray, a.length)))
     }
   }
 
-  it should "skip short reads when asked" in {
+  test("should skip short reads when asked") {
     forAll(dnaSeq(acgtn), dnaSeq(acgtn)) { (a: String, b: String) =>
       val read = Read("id", a + b)
       val policy = FixedOffsetPolicy(a.length + 1, b.length, skipShortReads = true)
-      policy.find(read) should be(None)
+      assertEquals(policy.find(read), None)
     }
   }
 
-  it should "reject short reads" in {
+  test("should reject short reads") {
     forAll(dnaSeq(acgtn), dnaSeq(acgtn)) { (a: String, b: String) =>
       val read = Read("id", a + b)
       val policy = FixedOffsetPolicy(a.length + 1, b.length, skipShortReads = false)
-      assertThrows[ReadTooShortException](policy.find(read))
+      Prop.secure {
+        val _ = intercept[ReadTooShortException] {
+          policy.find(read)
+        }
+        true
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
@@ -30,14 +30,16 @@ class IndexOfKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val barcodeLength = 20
     val minPrefixPos = 22
     val policy = IndexOfKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos))
+    // this generator cannot generate a CACCG prefix because it cannot generate a G
+    val notAllBases = Gen.oneOf('A', 'T', 'G')
     forAll(
-      dnaSeqMaxN(acgtn, minPrefixPos - prefix.length),
+      dnaSeqMaxN(notAllBases, minPrefixPos - prefix.length),
       Gen.chooseNum(0, minPrefixPos),
-      dnaSeqOfN(acgtn, barcodeLength)
+      dnaSeqOfN(notAllBases, barcodeLength)
     ) { (bases, prefixPos, barcode) =>
       val pre = bases.take(prefixPos)
       val post = bases.drop(prefixPos)
-      val seq = pre + "CACCG" + post + barcode
+      val seq = pre + prefix + post + barcode
       assertEquals(policy.find(Read("id", seq)), None)
     }
   }
@@ -48,8 +50,10 @@ class IndexOfKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val minPrefixPos = 22
     val maxPrefixPos = 29
     val policy = IndexOfKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos), Some(maxPrefixPos))
-    forAll(dnaSeqOfN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
-      val seq = pre + "CACCG" + barcode
+    // this generator cannot generate a CACCG prefix because it cannot generate a G
+    val notAllBases = Gen.oneOf('A', 'T', 'G')
+    forAll(dnaSeqOfN(notAllBases, maxPrefixPos + 1), dnaSeqOfN(notAllBases, barcodeLength)) { (pre, barcode) =>
+      val seq = pre + prefix + barcode
       assertEquals(policy.find(Read("id", seq)), None)
     }
   }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
@@ -30,7 +30,7 @@ class IndexOfKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val barcodeLength = 20
     val minPrefixPos = 22
     val policy = IndexOfKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos))
-    // this generator cannot generate a CACCG prefix because it cannot generate a G
+    // this generator cannot generate a CACCG prefix because it cannot generate a C
     val notAllBases = Gen.oneOf('A', 'T', 'G')
     forAll(
       dnaSeqMaxN(notAllBases, minPrefixPos - prefix.length),
@@ -50,7 +50,7 @@ class IndexOfKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val minPrefixPos = 22
     val maxPrefixPos = 29
     val policy = IndexOfKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos), Some(maxPrefixPos))
-    // this generator cannot generate a CACCG prefix because it cannot generate a G
+    // this generator cannot generate a CACCG prefix because it cannot generate a C
     val notAllBases = Gen.oneOf('A', 'T', 'G')
     forAll(dnaSeqOfN(notAllBases, maxPrefixPos + 1), dnaSeqOfN(notAllBases, barcodeLength)) { (pre, barcode) =>
       val seq = pre + prefix + barcode

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/IndexOfKnownPrefixPolicyTest.scala
@@ -5,28 +5,27 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgt, acgtn, dnaSeqMaxN, dnaSeqOfN}
 import org.broadinstitute.gpp.poolq3.types.Read
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class IndexOfKnownPrefixPolicyTest extends AnyFlatSpec:
+class IndexOfKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
 
   val fixed = "NNNNNNNNNNNN"
 
-  "find" should "find a barcode" in {
+  test("find should find a barcode") {
     forAll(dnaSeqMaxN(acgtn, 7), dnaSeqOfN(acgt, 5), dnaSeqOfN(acgtn, 20)) {
       (variable: String, prefix: String, barcode: String) =>
         val read = Read("id", variable + fixed + prefix + barcode)
         val policy = IndexOfKnownPrefixPolicy(prefix, barcode.length, Some(7))
         val found: Option[FoundBarcode] = policy.find(read)
-        found should be(Some(FoundBarcode(barcode.toCharArray, variable.length + fixed.length + prefix.length)))
+        assertEquals(found, Some(FoundBarcode(barcode.toCharArray, variable.length + fixed.length + prefix.length)))
     }
   }
 
-  it should "not find a barcode that's before the search window" in {
+  test("should not find a barcode that's before the search window") {
     val prefix = "CACCG"
     val barcodeLength = 20
     val minPrefixPos = 22
@@ -39,19 +38,19 @@ class IndexOfKnownPrefixPolicyTest extends AnyFlatSpec:
       val pre = bases.take(prefixPos)
       val post = bases.drop(prefixPos)
       val seq = pre + "CACCG" + post + barcode
-      policy.find(Read("id", seq)) should be(None)
+      assertEquals(policy.find(Read("id", seq)), None)
     }
   }
 
-  it should "not find a barcode that's after the search window" in {
+  test("should not find a barcode that's after the search window") {
     val prefix = "CACCG"
     val barcodeLength = 20
     val minPrefixPos = 22
     val maxPrefixPos = 29
     val policy = IndexOfKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos), Some(maxPrefixPos))
-    forAll(dnaSeqMaxN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
+    forAll(dnaSeqOfN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
       val seq = pre + "CACCG" + barcode
-      policy.find(Read("id", seq)) should be(None)
+      assertEquals(policy.find(Read("id", seq)), None)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KeyMaskTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KeyMaskTest.scala
@@ -5,76 +5,76 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
+import munit.FunSuite
 
-class KeyMaskTest extends AnyFlatSpec:
+class KeyMaskTest extends FunSuite:
 
-  "KeyMask.apply" should "construct the correct key mask from a pattern" in {
+  test("KeyMask.apply should construct the correct key mask from a pattern") {
     val km0 = KeyMask("NNNNNNNNNNNNNNNNN")
-    val _ = km0 should be(KeyMask.fromString(17, "1-17"))
+    assertEquals(km0, KeyMask.fromString(17, "1-17"))
     val km1 = KeyMask("NNNNNNNNNNNNNNNNNnNN")
-    val _ = km1 should be(KeyMask.fromString(20, "1-17,19-20"))
+    assertEquals(km1, KeyMask.fromString(20, "1-17,19-20"))
     val km2 = KeyMask("nNNNNNNNNNNNNNNNNNnNNn")
-    val _ = km2 should be(KeyMask.fromString(22, "2-18,20-21"))
+    assertEquals(km2, KeyMask.fromString(22, "2-18,20-21"))
     val km3 = KeyMask("nnnNNNNNNNNNNNNNNNNNnNNnN")
-    val _ = km3 should be(KeyMask.fromString(25, "4-20,22-23,25"))
+    assertEquals(km3, KeyMask.fromString(25, "4-20,22-23,25"))
     val km4 = KeyMask("nnnnNNNNNNNNNNNNNNNNNNNNnnnnnn")
-    km4 should be(KeyMask.fromString(30, "5-24"))
+    assertEquals(km4, KeyMask.fromString(30, "5-24"))
   }
 
-  it should "handle a very large context seq" in {
+  test("should handle a very large context seq") {
     //                 0                                                                                                   1                                                                                                   2
     //                 0         1         2         3         4         5         6         7         8         9         0         1         2         3         4         5         6         7         8         9         0         1         2         3
     //                 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
     val km5 = KeyMask(
       "caccgNNNNNNNNNNNNNNNNNNNNnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnNNNNNNNNNNNNNNNNNNNNN"
     )
-    val _ = km5.contextLength should be(240)
-    val _ = km5.keyLengthInBases should be(41)
-    km5.keyRanges should be(Seq(KeyRange(5, 24), KeyRange(219, 239)))
+    assertEquals(km5.contextLength, 240)
+    assertEquals(km5.keyLengthInBases, 41)
+    assertEquals(km5.keyRanges, Seq(KeyRange(5, 24), KeyRange(219, 239)))
   }
 
-  "KeyMask.fromString" should "compute the correct key mask from a list of key ranges in either syntax" in {
+  test("KeyMask.fromString should compute the correct key mask from a list of key ranges in either syntax") {
     val km1 = KeyMask.fromString(23, "4-20,22-23")
-    val _ = km1 should be(KeyMask(23, Seq(KeyRange(3, 19), KeyRange(21, 22))))
+    assertEquals(km1, KeyMask(23, Seq(KeyRange(3, 19), KeyRange(21, 22))))
     val km2 = KeyMask.fromString(23, "4..20,22..23")
-    km2 should be(KeyMask(23, Seq(KeyRange(3, 19), KeyRange(21, 22))))
+    assertEquals(km2, KeyMask(23, Seq(KeyRange(3, 19), KeyRange(21, 22))))
   }
 
-  "KeyMask.mergeAdjacent" should "handle an empty list" in {
-    KeyMask.mergeAdjacent(Seq[KeyRange]()) should be(Seq[KeyRange]())
+  test("KeyMask.mergeAdjacent should handle an empty list") {
+    assertEquals(KeyMask.mergeAdjacent(Seq[KeyRange]()), Seq[KeyRange]())
   }
 
-  it should "handle a singleton" in {
-    KeyMask.mergeAdjacent(Seq(KeyRange(3, 19))) should be(Seq(KeyRange(3, 19)))
+  test("should handle a singleton") {
+    assertEquals(KeyMask.mergeAdjacent(Seq(KeyRange(3, 19))), Seq(KeyRange(3, 19)))
   }
 
-  it should "handle disjoint ranges" in {
-    KeyMask.mergeAdjacent(Seq(KeyRange(3, 19), KeyRange(21, 22))) should be(Seq(KeyRange(3, 19), KeyRange(21, 22)))
+  test("should handle disjoint ranges") {
+    assertEquals(KeyMask.mergeAdjacent(Seq(KeyRange(3, 19), KeyRange(21, 22))), Seq(KeyRange(3, 19), KeyRange(21, 22)))
   }
 
-  it should "merge contiguous ranges" in {
-    KeyMask.mergeAdjacent(Seq(KeyRange(3, 21), KeyRange(21, 22))) should be(Seq(KeyRange(3, 22)))
+  test("should merge contiguous ranges") {
+    assertEquals(KeyMask.mergeAdjacent(Seq(KeyRange(3, 21), KeyRange(21, 22))), Seq(KeyRange(3, 22)))
   }
 
-  it should "merge adjacent ranges" in {
-    val _ = KeyMask.mergeAdjacent(Seq(KeyRange(1, 9), KeyRange(10, 12), KeyRange(14, 17))) should be(
+  test("should merge adjacent ranges") {
+    assertEquals(
+      KeyMask.mergeAdjacent(Seq(KeyRange(1, 9), KeyRange(10, 12), KeyRange(14, 17))),
       Seq(KeyRange(1, 12), KeyRange(14, 17))
     )
-    KeyMask.fromString(10, "1,2..4,5,6-8,9") should be(KeyMask.fromString(10, "1-9"))
+    assertEquals(KeyMask.fromString(10, "1,2..4,5,6-8,9"), KeyMask.fromString(10, "1-9"))
   }
 
-  "KeyMask#indexedRanges" should "construct ranges from a simple pattern" in {
-    KeyMask.parsePatternRanges("NNNN") should be(List(KeyRange(0, 3)))
+  test("KeyMask#indexedRanges should construct ranges from a simple pattern") {
+    assertEquals(KeyMask.parsePatternRanges("NNNN"), List(KeyRange(0, 3)))
   }
 
-  it should "handle leading and trailing gaps" in {
-    KeyMask.parsePatternRanges("nNNNNn") should be(List(KeyRange(1, 4)))
+  test("should handle leading and trailing gaps") {
+    assertEquals(KeyMask.parsePatternRanges("nNNNNn"), List(KeyRange(1, 4)))
   }
 
-  it should "handle an interior gap" in {
-    KeyMask.parsePatternRanges("nNNnNNn") should be(List(KeyRange(1, 2), KeyRange(4, 5)))
+  test("should handle an interior gap") {
+    assertEquals(KeyMask.parsePatternRanges("nNNnNNn"), List(KeyRange(1, 2), KeyRange(4, 5)))
   }
 
 end KeyMaskTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KeyRangeTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KeyRangeTest.scala
@@ -5,42 +5,41 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
+import munit.FunSuite
 
 /** @author
   *   Broad Institute Genetic Perturbation Platform
   */
-class KeyRangeTest extends AnyFlatSpec:
+class KeyRangeTest extends FunSuite:
 
-  "KeyRange" should "enforce well-formedness" in {
-    val _ = noException should be thrownBy KeyRange(3, 4)
-    val _ = noException should be thrownBy KeyRange(3, 3)
-    val _ = an[IllegalArgumentException] should be thrownBy KeyRange(3, 2)
-    an[IllegalArgumentException] should be thrownBy KeyRange(-2, 2)
+  test("KeyRange should enforce well-formedness") {
+    val _ = KeyRange(3, 4)
+    val _ = KeyRange(3, 3)
+    val _ = intercept[IllegalArgumentException](KeyRange(3, 2))
+    val _ = intercept[IllegalArgumentException](KeyRange(-2, 2))
   }
 
-  it should "have working compare()" in {
+  test("should have working compare()") {
     val ord = implicitly[Ordering[KeyRange]]
-    val _ = ord.compare(KeyRange(2, 5), KeyRange(2, 5)) should be(0)
-    val _ = KeyRange(2, 5) should be <= KeyRange(2, 5)
-    val _ = KeyRange(2, 5) should be >= KeyRange(2, 5)
+    assertEquals(ord.compare(KeyRange(2, 5), KeyRange(2, 5)), 0)
+    assert(ord.lteq(KeyRange(2, 5), KeyRange(2, 5)))
+    assert(ord.gteq(KeyRange(2, 5), KeyRange(2, 5)))
 
-    val _ = KeyRange(2, 5) should be < KeyRange(3, 4)
-    val _ = KeyRange(2, 5) should be < KeyRange(2, 6)
-    val _ = KeyRange(2, 5) should be > KeyRange(2, 4)
-    KeyRange(2, 5) should be > KeyRange(1, 32)
+    assert(ord.lt(KeyRange(2, 5), KeyRange(3, 4)))
+    assert(ord.lt(KeyRange(2, 5), KeyRange(2, 6)))
+    assert(ord.gt(KeyRange(2, 5), KeyRange(2, 4)))
+    assert(ord.gt(KeyRange(2, 5), KeyRange(1, 32)))
   }
 
-  it should "be creatable from a string" in {
-    val _ = KeyRange("1-1") should be(KeyRange(0, 0))
-    val _ = KeyRange("1..1") should be(KeyRange(0, 0))
-    val _ = KeyRange("1") should be(KeyRange(0, 0))
-    val _ = KeyRange("1-6") should be(KeyRange(0, 5))
-    val _ = KeyRange("1..6") should be(KeyRange(0, 5))
-    val _ = an[IllegalArgumentException] should be thrownBy KeyRange("0-5")
-    val _ = an[IllegalArgumentException] should be thrownBy KeyRange("-1-5")
-    an[IllegalArgumentException] should be thrownBy KeyRange("6-5")
+  test("should be creatable from a string") {
+    assertEquals(KeyRange("1-1"), KeyRange(0, 0))
+    assertEquals(KeyRange("1..1"), KeyRange(0, 0))
+    assertEquals(KeyRange("1"), KeyRange(0, 0))
+    assertEquals(KeyRange("1-6"), KeyRange(0, 5))
+    assertEquals(KeyRange("1..6"), KeyRange(0, 5))
+    val _ = intercept[IllegalArgumentException](KeyRange("0-5"))
+    val _ = intercept[IllegalArgumentException](KeyRange("-1-5"))
+    val _ = intercept[IllegalArgumentException](KeyRange("6-5"))
   }
 
 end KeyRangeTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KmpKnownPrefixPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KmpKnownPrefixPolicyTest.scala
@@ -44,14 +44,15 @@ class KmpKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val barcodeLength = 20
     val minPrefixPos = 22
     val policy = KmpKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos))
+    val nonPrefixBase = Gen.oneOf('A', 'T', 'N')
     forAll(
-      dnaSeqMaxN(acgtn, minPrefixPos - prefix.length),
+      dnaSeqMaxN(nonPrefixBase, minPrefixPos - prefix.length),
       Gen.chooseNum(0, minPrefixPos),
-      dnaSeqOfN(acgtn, barcodeLength)
+      dnaSeqOfN(nonPrefixBase, barcodeLength)
     ) { (bases, prefixPos, barcode) =>
       val pre = bases.take(prefixPos)
       val post = bases.drop(prefixPos)
-      val seq = pre + "CACCG" + post + barcode
+      val seq = pre + prefix + post + barcode
       assertEquals(policy.find(Read("id", seq)), None)
     }
   }
@@ -62,8 +63,9 @@ class KmpKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
     val minPrefixPos = 22
     val maxPrefixPos = 29
     val policy = KmpKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos), Some(maxPrefixPos))
-    forAll(dnaSeqOfN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
-      val seq = pre + "CACCG" + barcode
+    val nonPrefixBase = Gen.oneOf('A', 'T', 'N')
+    forAll(dnaSeqOfN(nonPrefixBase, maxPrefixPos + 1), dnaSeqOfN(nonPrefixBase, barcodeLength)) { (pre, barcode) =>
+      val seq = pre + prefix + barcode
       assertEquals(policy.find(Read("id", seq)), None)
     }
   }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KmpKnownPrefixPolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KmpKnownPrefixPolicyTest.scala
@@ -5,28 +5,27 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgt, acgtn, dnaSeqMaxN, dnaSeqOfN}
 import org.broadinstitute.gpp.poolq3.types.Read
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class KmpKnownPrefixPolicyTest extends AnyFlatSpec:
+class KmpKnownPrefixPolicyTest extends FunSuite with ScalaCheckSuite:
 
   val fixed = "NNNNNNNNNNNN"
 
-  "find" should "find a barcode" in {
+  test("find should find a barcode") {
     forAll(dnaSeqMaxN(acgtn, 7), dnaSeqOfN(acgt, 5), dnaSeqOfN(acgtn, 20)) {
       (variable: String, prefix: String, barcode: String) =>
         val read = Read("id", variable + fixed + prefix + barcode)
         val policy = KmpKnownPrefixPolicy(prefix, barcode.length, Some(7))
         val found: Option[FoundBarcode] = policy.find(read)
-        found should be(Some(FoundBarcode(barcode.toCharArray, variable.length + fixed.length + prefix.length)))
+        assertEquals(found, Some(FoundBarcode(barcode.toCharArray, variable.length + fixed.length + prefix.length)))
     }
   }
 
-  it should "work for these cases" in {
+  test("should work for these cases") {
     val reads = Seq(
       "GGTCACCGATCAACGCACCTCCATCCACCGACCACACAGCTTGGACCTTT",
       "GGTCACCGTCACCTCCATCCACCGACCACACAGCTTGGACCTTTGGCATG",
@@ -36,11 +35,11 @@ class KmpKnownPrefixPolicyTest extends AnyFlatSpec:
     reads.foreach { read =>
       val r = new Read("id", read)
       val actual = policy.find(r)
-      actual.isDefined should be(true)
+      assert(actual.isDefined)
     }
   }
 
-  it should "not find a barcode that's before the search window" in {
+  test("should not find a barcode that's before the search window") {
     val prefix = "CACCG"
     val barcodeLength = 20
     val minPrefixPos = 22
@@ -53,19 +52,19 @@ class KmpKnownPrefixPolicyTest extends AnyFlatSpec:
       val pre = bases.take(prefixPos)
       val post = bases.drop(prefixPos)
       val seq = pre + "CACCG" + post + barcode
-      policy.find(Read("id", seq)) should be(None)
+      assertEquals(policy.find(Read("id", seq)), None)
     }
   }
 
-  it should "not find a barcode that's after the search window" in {
+  test("should not find a barcode that's after the search window") {
     val prefix = "CACCG"
     val barcodeLength = 20
     val minPrefixPos = 22
     val maxPrefixPos = 29
     val policy = KmpKnownPrefixPolicy(prefix, barcodeLength, Some(minPrefixPos), Some(maxPrefixPos))
-    forAll(dnaSeqMaxN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
+    forAll(dnaSeqOfN(acgtn, maxPrefixPos + 1), dnaSeqOfN(acgtn, barcodeLength)) { (pre, barcode) =>
       val seq = pre + "CACCG" + barcode
-      policy.find(Read("id", seq)) should be(None)
+      assertEquals(policy.find(Read("id", seq)), None)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KnownPrefixPolicyBenchmark.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KnownPrefixPolicyBenchmark.scala
@@ -5,12 +5,12 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.types.Read
-import org.scalatest.flatspec.AnyFlatSpec
 
-class KnownPrefixPolicyBenchmark extends AnyFlatSpec:
+class KnownPrefixPolicyBenchmark extends FunSuite:
 
-  ignore should "compare times" in {
+  test("should compare times".ignore) {
     val seqs = Seq(
       "AGCTTGTGGAAAGGACGAAACACCGGCGCTGGTAGTTCGAACCCGGTTTT",
       "GCTTGTGGAAAGGACGAAACACCGGGGCCTCTCACCTTCCACGAGTTTTA",

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KnuthMorrisPrattTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/KnuthMorrisPrattTest.scala
@@ -5,21 +5,20 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgtn, dnaSeq}
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class KnuthMorrisPrattTest extends AnyFlatSpec:
+class KnuthMorrisPrattTest extends FunSuite with ScalaCheckSuite:
 
   private val prefixGen: Gen[String] = dnaSeq(acgtn).suchThat(!_.contains("CACCG"))
 
-  "KnuthMorrisPratt" should "find CACCG" in {
+  test("KnuthMorrisPratt should find CACCG") {
     val kmp = new KnuthMorrisPratt("CACCG")
     forAll(prefixGen, dnaSeq(acgtn)) { (s1: String, s2: String) =>
       val s = s"${s1}CACCG$s2"
-      kmp.search(s) should be(Some(s1.length))
+      assertEquals(kmp.search(s), Some(s1.length))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/TemplatePolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/TemplatePolicyTest.scala
@@ -13,7 +13,7 @@ import org.scalacheck.Prop.forAll
 
 class TemplatePolicyTest extends FunSuite with ScalaCheckSuite {
 
-  test("KeyMaskPolicy should do a thing") {
+  test("KeyMaskPolicy should work in the simple case") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/TemplatePolicyTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/barcode/TemplatePolicyTest.scala
@@ -5,16 +5,15 @@
  */
 package org.broadinstitute.gpp.poolq3.barcode
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgt, acgtn, dnaSeqMaxN, dnaSeqOfN}
 import org.broadinstitute.gpp.poolq3.tools.nanoTimed
 import org.broadinstitute.gpp.poolq3.types.Read
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class TemplatePolicyTest extends AnyFlatSpec {
+class TemplatePolicyTest extends FunSuite with ScalaCheckSuite {
 
-  "KeyMaskPolicy" should "do a thing" in {
+  test("KeyMaskPolicy should do a thing") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 
@@ -25,10 +24,10 @@ class TemplatePolicyTest extends AnyFlatSpec {
     //         01234567890123456789012345678901234567890123456789
     val seq = "CTTGTGGAAATGACGAACCACCGATAGCCAAGAATTATTACAAGTTTTAG"
 
-    kmp.find(Read("", seq)) should be(Some(FoundBarcode("ATAGCAGTTT".toCharArray, 23)))
+    assertEquals(kmp.find(Read("", seq)), Some(FoundBarcode("ATAGCAGTTT".toCharArray, 23)))
   }
 
-  it should "find a seq at the right edge of the read" in {
+  test("should find a seq at the right edge of the read") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 
@@ -37,11 +36,11 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "CTTGTGGAAATGACGAACCACCACCGGCCAAGAATTATTATTACATTTAG"
     //                              caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(Some(FoundBarcode("GCCAATTTAG".toCharArray, 26)))
+    assertEquals(kmp.find(Read("", seq)), Some(FoundBarcode("GCCAATTTAG".toCharArray, 26)))
   }
 
   // this is the same case as above, but I deleted the last base of the seq
-  it should "not find a seq past the right edge of the read" in {
+  test("should not find a seq past the right edge of the read") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 
@@ -50,10 +49,10 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "CTTGTGGAAATGACGAACCACCACCGGCCAAGAATTATTATTACATTTA"
     //                              caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(None)
+    assertEquals(kmp.find(Read("", seq)), None)
   }
 
-  it should "find a seq at the min start pos" in {
+  test("should find a seq at the min start pos") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 
@@ -62,11 +61,11 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "CTTGTGGAAATCACCGACCACCACCGGCCATTACATATTATTACATTTAG"
     //                    caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(Some(FoundBarcode("ACCACTATTA".toCharArray, 16)))
+    assertEquals(kmp.find(Read("", seq)), Some(FoundBarcode("ACCACTATTA".toCharArray, 16)))
   }
 
   // this is the same case as above, but I deleted the first base of the seq
-  it should "not find a seq before the min start pos" in {
+  test("should not find a seq before the min start pos") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11))
 
@@ -75,10 +74,10 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "TTGTGGAAATCACCGACCACCACTGGCCATTACATATTATTACATTTAG"
     //                   caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(None)
+    assertEquals(kmp.find(Read("", seq)), None)
   }
 
-  it should "find a seq at the max start pos" in {
+  test("should find a seq at the max start pos") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(11), Some(11))
 
@@ -87,10 +86,10 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "CTTGTGGAAATCACCGACCACCACCGGCCATTACATATTATTACATTTAG"
     //                    caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(Some(FoundBarcode("ACCACTATTA".toCharArray, 16)))
+    assertEquals(kmp.find(Read("", seq)), Some(FoundBarcode("ACCACTATTA".toCharArray, 16)))
   }
 
-  it should "not find a seq past the max start pos" in {
+  test("should not find a seq past the max start pos") {
     val km = KeyMask("caccgNNNNNnnnnnnnnnttacaNNNNN")
     val kmp = GeneralTemplatePolicy(km, Some(5), Some(10))
 
@@ -99,10 +98,10 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val seq = "CTTGTGGAAATCACCGACCACCACCGGCCATTACATATTATTACATTTAG"
     //                    caccgNNNNNnnnnnnnnnttacaNNNNN
 
-    kmp.find(Read("", seq)) should be(None)
+    assertEquals(kmp.find(Read("", seq)), None)
   }
 
-  it should "handle a very long read" in {
+  test("should handle a very long read") {
     // format: off
     val pattern = "caccgNNNNNNNNNNNNNNNNNNNNnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnNNNNNNNNNNNNNNNNNNNNN"
     val read1   = "CACCGTTTTTTTTTTTTTTTTTTTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTTTTTTTTTTTTTTTTTTT"
@@ -113,16 +112,18 @@ class TemplatePolicyTest extends AnyFlatSpec {
     val keymask = KeyMask(pattern)
     val kmp = new GeneralTemplatePolicy(keymask, Some(0))
 
-    val _ = kmp.find(Read("", read1)) should be(
+    assertEquals(
+      kmp.find(Read("", read1)),
       Some(FoundBarcode("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT".toCharArray, 5))
     )
-    val _ = kmp.find(Read("", read2)) should be(
+    assertEquals(
+      kmp.find(Read("", read2)),
       Some(FoundBarcode("NTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT".toCharArray, 5))
     )
-    kmp.find(Read("", read3)) should be(None)
+    assertEquals(kmp.find(Read("", read3)), None)
   }
 
-  ignore should "not be too slow given some random barcodes" in {
+  test("should not be too slow given some random barcodes".ignore) {
     val fixed = "ACTTGCATTGCAATGTGA"
     val prefix1 = "CACCG"
     val prefix2 = "TTACA"
@@ -147,7 +148,7 @@ class TemplatePolicyTest extends AnyFlatSpec {
         println(s"indexof: $t2 ratio: 1.0")
         println(s"keymask: $t1 ratio: $ratio1")
 
-        ret1 should be(ret2)
+        assertEquals(ret1, ret2)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/collection/CollectionPackageTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/collection/CollectionPackageTest.scala
@@ -5,12 +5,11 @@
  */
 package org.broadinstitute.gpp.poolq3.collection
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
+import munit.FunSuite
 
-class CollectionPackageTest extends AnyFlatSpec:
+class CollectionPackageTest extends FunSuite:
 
-  "zipWithIndex1" should "produce indexes starting with 1" in {
+  test("zipWithIndex1 should produce indexes starting with 1") {
     val input = Seq("a", "b", "c")
-    input.iterator.zipWithIndex1.toSeq should be(Seq(("a", 1), ("b", 2), ("c", 3)))
+    assertEquals(input.iterator.zipWithIndex1.toSeq, Seq(("a", 1), ("b", 2), ("c", 3)))
   }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/integration/AmbiguousMatchTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/integration/AmbiguousMatchTest.scala
@@ -5,15 +5,14 @@
  */
 package org.broadinstitute.gpp.poolq3.integration
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.PoolQ
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.parser.{CloseableIterable, ReferenceEntry}
 import org.broadinstitute.gpp.poolq3.process.ScoringConsumer
 import org.broadinstitute.gpp.poolq3.reference.{ExactReference, VariantReference}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class AmbiguousMatchTest extends AnyFlatSpec:
+class AmbiguousMatchTest extends FunSuite:
 
   private val rowReferenceBarcodes = List(
     "AAAAAAAAAAAAAAAAAAAA",
@@ -56,50 +55,50 @@ class AmbiguousMatchTest extends AnyFlatSpec:
     }
   )
 
-  "PoolQ" should "count ambiguous bases" in {
+  test("PoolQ should count ambiguous bases") {
     val consumer = new ScoringConsumer(rowReference, colReference, countAmbiguous = true, false, None, None, false)
 
     val ret = PoolQ.runProcess(barcodes, consumer)
     val state = ret.get.state
 
-    val _ = state.reads should be(9)
-    val _ = state.exactMatches should be(3)
+    assertEquals(state.reads, 9L)
+    assertEquals(state.exactMatches, 3L)
 
     val hist = state.known
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")) should be(1)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAT")) should be(1)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAA")) should be(1)
-    val _ = hist.count(("CCGGTTGATGCGTGGTGATG", "CCCC")) should be(1)
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "CCCG")) should be(1)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")), 1L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAT")), 1L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAA")), 1L)
+    assertEquals(hist.count(("CCGGTTGATGCGTGGTGATG", "CCCC")), 1L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "CCCG")), 1L)
 
     // these all correspond to the ambiguous match at the end
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCC")) should be(1)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCC")) should be(1)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCC")) should be(1)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCC")) should be(1)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCC")), 1L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCC")), 1L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCC")), 1L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCC")), 1L)
 
     // these are combinations that didn't occur
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCG")), 0L)
 
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAT")) should be(0)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCC")) should be(0)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCG")) should be(0)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAT")), 0L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCC")), 0L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCG")), 0L)
 
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "AAAA")) should be(0)
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "AAAT")) should be(0)
-    hist.count(("AATGTGAAAATGTGATGAAT", "CCCC")) should be(0)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "AAAA")), 0L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "AAAT")), 0L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "CCCC")), 0L)
   }
 
 end AmbiguousMatchTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/integration/LongBarcodeMatchTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/integration/LongBarcodeMatchTest.scala
@@ -5,15 +5,14 @@
  */
 package org.broadinstitute.gpp.poolq3.integration
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.PoolQ
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.parser.{CloseableIterable, ReferenceEntry}
 import org.broadinstitute.gpp.poolq3.process.ScoringConsumer
 import org.broadinstitute.gpp.poolq3.reference.{ExactReference, VariantReference}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class LongBarcodeMatchTest extends AnyFlatSpec:
+class LongBarcodeMatchTest extends FunSuite:
 
   private val rowReferenceBarcodes = List(
     ReferenceEntry(
@@ -88,43 +87,55 @@ class LongBarcodeMatchTest extends AnyFlatSpec:
     }
   )
 
-  "PoolQ" should "count ambiguous bases" in {
+  test("PoolQ should count ambiguous bases") {
     val consumer = new ScoringConsumer(rowReference, colReference, countAmbiguous = true, false, None, None, false)
 
     val ret = PoolQ.runProcess(barcodes, consumer)
     val state = ret.get.state
 
-    val _ = state.reads should be(9)
-    val _ = state.exactMatches should be(2)
-    val _ = state.matches should be(4)
+    assertEquals(state.reads, 9L)
+    assertEquals(state.exactMatches, 2L)
+    assertEquals(state.matches, 4L)
 
     val hist = state.known
 
     // these are all the matches
-    val _ = hist.count(
-      (
-        "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
-        "AAAT"
-      )
-    ) should be(1)
-    val _ = hist.count(
-      (
-        "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
-        "AAAA"
-      )
-    ) should be(1)
-    val _ = hist.count(
-      (
-        "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
-        "CCCG"
-      )
-    ) should be(1)
-    hist.count(
-      (
-        "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
-        "CCCC"
-      )
-    ) should be(1)
+    assertEquals(
+      hist.count(
+        (
+          "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
+          "AAAT"
+        )
+      ),
+      1L
+    )
+    assertEquals(
+      hist.count(
+        (
+          "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
+          "AAAA"
+        )
+      ),
+      1L
+    )
+    assertEquals(
+      hist.count(
+        (
+          "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
+          "CCCG"
+        )
+      ),
+      1L
+    )
+    assertEquals(
+      hist.count(
+        (
+          "TTTCTGTCATCCAAATACTCCACACGCAAATTTCCTTCCACTCGGATAAGATGCTGAGGAGGGGCCAGACCTAAGAGCAATCAGTGAGGAATCAGAGGCCTGGGGACCCTGGGCAACCAGCCCTGTCGTCTCTCCAGCCCCAGC",
+          "CCCC"
+        )
+      ),
+      1L
+    )
   }
 
 end LongBarcodeMatchTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/integration/UnambiguousMatchTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/integration/UnambiguousMatchTest.scala
@@ -5,15 +5,14 @@
  */
 package org.broadinstitute.gpp.poolq3.integration
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.PoolQ
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.parser.{CloseableIterable, ReferenceEntry}
 import org.broadinstitute.gpp.poolq3.process.ScoringConsumer
 import org.broadinstitute.gpp.poolq3.reference.{ExactReference, VariantReference}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class UnambiguousMatchTest extends AnyFlatSpec:
+class UnambiguousMatchTest extends FunSuite:
 
   private val rowReferenceBarcodes = List(
     "AAAAAAAAAAAAAAAAAAAA",
@@ -56,50 +55,50 @@ class UnambiguousMatchTest extends AnyFlatSpec:
     }
   )
 
-  "PoolQ" should "not count ambiguous bases" in {
+  test("PoolQ should not count ambiguous bases") {
     val consumer = new ScoringConsumer(rowReference, colReference, countAmbiguous = true, false, None, None, false)
 
     val ret = PoolQ.runProcess(barcodes, consumer)
     val state = ret.get.state
 
-    val _ = state.reads should be(9)
-    val _ = state.exactMatches should be(3)
+    assertEquals(state.reads, 9L)
+    assertEquals(state.exactMatches, 3L)
 
     val hist = state.known
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")) should be(1)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAT")) should be(1)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAA")) should be(1)
-    val _ = hist.count(("CCGGTTGATGCGTGGTGATG", "CCCC")) should be(1)
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "CCCG")) should be(1)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")), 1L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAT")), 1L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAA")), 1L)
+    assertEquals(hist.count(("CCGGTTGATGCGTGGTGATG", "CCCC")), 1L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "CCCG")), 1L)
 
     // these all correspond to the ambiguous match at the end
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCC")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCC")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCC")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCC")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCC")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCC")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCC")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCC")), 0L)
 
     // these are combinations that didn't occur
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAC", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAG", "CCCG")), 0L)
 
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAA")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAT")) should be(0)
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCG")) should be(0)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAA")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "AAAT")), 0L)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAT", "CCCG")), 0L)
 
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAT")) should be(0)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCC")) should be(0)
-    val _ = hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCG")) should be(0)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "AAAT")), 0L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCC")), 0L)
+    assertEquals(hist.count(("GATGTGCAGTGAGTAGCGAG", "CCCG")), 0L)
 
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "AAAA")) should be(0)
-    val _ = hist.count(("AATGTGAAAATGTGATGAAT", "AAAT")) should be(0)
-    hist.count(("AATGTGAAAATGTGATGAAT", "CCCC")) should be(0)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "AAAA")), 0L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "AAAT")), 0L)
+    assertEquals(hist.count(("AATGTGAAAATGTGATGAAT", "CCCC")), 0L)
   }
 
 end UnambiguousMatchTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/integration/UnambiguousVariantTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/integration/UnambiguousVariantTest.scala
@@ -5,15 +5,14 @@
  */
 package org.broadinstitute.gpp.poolq3.integration
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.PoolQ
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.parser.{CloseableIterable, ReferenceEntry}
 import org.broadinstitute.gpp.poolq3.process.ScoringConsumer
 import org.broadinstitute.gpp.poolq3.reference.{ExactReference, VariantReference}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class UnambiguousVariantTest extends AnyFlatSpec:
+class UnambiguousVariantTest extends FunSuite:
 
   private val rowReferenceBarcodes = List("AAAAAAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAAAAAC").map(b => ReferenceEntry(b, b))
 
@@ -35,23 +34,23 @@ class UnambiguousVariantTest extends AnyFlatSpec:
     }
   }
 
-  "PoolQ" should "match a read with an N" in {
+  test("PoolQ should match a read with an N") {
     val consumer = new ScoringConsumer(rowReference, colReference, countAmbiguous = true, false, None, None, false)
 
     val ret = PoolQ.runProcess(reads, consumer)
     val state = ret.get.state
 
-    val _ = state.reads should be(1)
-    val _ = state.exactMatches should be(0)
+    assertEquals(state.reads, 1L)
+    assertEquals(state.exactMatches, 0L)
 
     val hist = state.known
-    val _ = hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")) should be(1)
+    assertEquals(hist.count(("AAAAAAAAAAAAAAAAAAAA", "AAAA")), 1L)
     for
       row <- rowReferenceBarcodes.map(_.dnaBarcode)
       col <- colReferenceBarcodes.map(_.dnaBarcode)
     do
-      val expected = if row.forall(_ == 'A') && col.forall(_ == 'A') then 1 else 0
-      hist.count((row, col)) should be(expected)
+      val expected = if row.forall(_ == 'A') && col.forall(_ == 'A') then 1L else 0L
+      assertEquals(hist.count((row, col)), expected)
   }
 
 end UnambiguousVariantTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/integration/legacy/LegacyIntegrationTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/integration/legacy/LegacyIntegrationTest.scala
@@ -8,16 +8,15 @@ package org.broadinstitute.gpp.poolq3.integration.legacy
 import java.nio.file.Path
 
 import better.files.*
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.reports.PoolQ2Dialect
 import org.broadinstitute.gpp.poolq3.testutil.contents
 import org.broadinstitute.gpp.poolq3.{PoolQ, PoolQConfig, PoolQInput, PoolQOutput, TestResources}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
+class LegacyIntegrationTest extends FunSuite with TestResources:
 
   private def filesSame(actual: Path, expected: Path): Unit =
-    val _ = contents(actual) should be(contents(expected))
+    assertEquals(contents(actual), contents(expected))
 
   /** Tests PoolQ end-to-end, using 10000 reads, 8 constructs, and 42 conditions. Compares the results to expected
     * results.
@@ -26,7 +25,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
     *
     * NOTE: the correctness of the results was verified by hand.
     */
-  "PoolQ" should "testPoolQReads10000Reference8Conditions42" in {
+  test("PoolQ should testPoolQReads10000Reference8Conditions42") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       barcodeCountsFile <- File.temporaryFile("barcode-counts", ".txt")
@@ -66,10 +65,10 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
       filesSame(normalizedCountsFile.path, resourcePath("lognorm-10000-8-42.txt"))
       filesSame(barcodeCountsFile.path, resourcePath("barcode-counts-10000-8-42.txt"))
       filesSame(qualityFile.path, resourcePath("quality-10000-8-42.txt"))
-      unexpectedSequenceCacheDir.exists should be(false)
+      assertEquals(unexpectedSequenceCacheDir.exists, false)
   }
 
-  "PoolQ" should "optionally not remove the unexpected sequence cache" in {
+  test("PoolQ should optionally not remove the unexpected sequence cache") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       barcodeCountsFile <- File.temporaryFile("barcode-counts", ".txt")
@@ -110,7 +109,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
       filesSame(normalizedCountsFile.path, resourcePath("lognorm-10000-8-42.txt"))
       filesSame(barcodeCountsFile.path, resourcePath("barcode-counts-10000-8-42.txt"))
       filesSame(qualityFile.path, resourcePath("quality-10000-8-42.txt"))
-      unexpectedSequenceCacheDir.exists should be(true)
+      assertEquals(unexpectedSequenceCacheDir.exists, true)
   }
 
   /** Tests PoolQ end-to-end, using 42 base reads. The longer reads allow for comparison with the whole construct, and
@@ -121,7 +120,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
     * construct have a single base mismatch 1 read that matches the first construct, but with a barcode that is not in
     * the conditions file one successful read each for the first 10 conditions
     */
-  it should "testPoolQLongerReads" in {
+  test("should testPoolQLongerReads") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       normalizedCountsFile <- File.temporaryFile("normcounts", ".txt")
@@ -166,7 +165,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
   /** Tests PoolQ end-to-end, using 42-base reads. The longer reads allow for comparison with the whole construct, and
     * also test the fact that PoolQ ignores any bases in the read that follow the construct.
     */
-  it should "testPoolQMultipleBarcodesPerCondition" in {
+  test("should testPoolQMultipleBarcodesPerCondition") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       normalizedCountsFile <- File.temporaryFile("normcounts", ".txt")
@@ -212,7 +211,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
   /** Tests the case of multiplexed reads, where the reads are long enough to contain the entire construct barcode
     * sequence.
     */
-  it should "testPoolQMultiplexedReads" in {
+  test("should testPoolQMultiplexedReads") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       normalizedCountsFile <- File.temporaryFile("normcounts", ".txt")
@@ -253,7 +252,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
       filesSame(qualityFile.toJava.toPath, resourcePath("next500-quality.txt"))
   }
 
-  it should "testPoolQMultiplexedShortReads" in {
+  test("should testPoolQMultiplexedShortReads") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       normalizedCountsFile <- File.temporaryFile("normcounts", ".txt")
@@ -298,7 +297,7 @@ class LegacyIntegrationTest extends AnyFlatSpec with TestResources:
     * also tests the fact that PoolQ ignores any bases in the read that follow the construct. In this example, one
     * barcode maps to multiple construct IDs.
     */
-  it should "testPoolQDuplicateConstructs" in {
+  test("should testPoolQDuplicateConstructs") {
     for
       countsFile <- File.temporaryFile("counts", ".txt")
       normalizedCountsFile <- File.temporaryFile("normcounts", ".txt")

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/numeric/NumericPackageTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/numeric/NumericPackageTest.scala
@@ -5,29 +5,29 @@
  */
 package org.broadinstitute.gpp.poolq3.numeric
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class NumericPackageTest extends AnyFlatSpec:
+class NumericPackageTest extends FunSuite with ScalaCheckSuite:
 
-  "log2" should "take the log base 2" in {
+  test("log2 should take the log base 2") {
     val smallNonNeg = Gen.chooseNum(0.0, 48.0)
-    forAll(smallNonNeg)((x: Double) => log2(math.pow(2, x)) should be(x +- .00000000000001))
-  }
-
-  "logNormalize" should "not divide by zero" in {
-    val _ = logNormalize(0, 132656131) should be(0)
-    val _ = logNormalize(0, 0) should be(0)
-    logNormalize(1, 0) should be(0)
-  }
-
-  it should "compute values" in {
-    forAll(Gen.posNum[Int], Gen.posNum[Int]) { (x: Int, y: Int) =>
-      implicit val ord: Ordering[Double] = Ordering.Double.IeeeOrdering
-      logNormalize(x, y) should be >= 0.0
+    forAll(smallNonNeg) { (x: Double) =>
+      val expected = x
+      val actual = log2(math.pow(2, x))
+      assert(math.abs(actual - expected) <= .00000000000001)
     }
+  }
+
+  test("logNormalize should not divide by zero") {
+    assertEquals(logNormalize(0, 132656131), 0.0)
+    assertEquals(logNormalize(0, 0), 0.0)
+    assertEquals(logNormalize(1, 0), 0.0)
+  }
+
+  test("should compute values") {
+    forAll(Gen.posNum[Int], Gen.posNum[Int])((x: Int, y: Int) => assert(logNormalize(x, y) >= 0.0))
   }
 
 end NumericPackageTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
@@ -69,4 +69,16 @@ class FastqParserTest extends AnyFlatSpec:
     finally file.delete()
   }
 
+  it should "reject a file ending with only 1 line" in {
+    val data = "@HWUSI-EAS100R:6:23:398:3989#1"
+    val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
+    try
+      file.overwrite(data)
+      val fqp = new FastqParser(file.path)
+      intercept[InvalidFileException] {
+        fqp.toList
+      }
+    finally file.delete()
+  }
+
 end FastqParserTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
@@ -5,6 +5,8 @@
  */
 package org.broadinstitute.gpp.poolq3.parser
 
+import scala.util.Using
+
 import better.files.*
 import munit.FunSuite
 
@@ -23,9 +25,8 @@ class FastqParserTest extends FunSuite:
     val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
     try
       file.overwrite(data)
-      val fqp = new FastqParser(file.path)
       intercept[InvalidFileException] {
-        fqp.toList
+        Using.resource(new FastqParser(file.path).iterator)(iter => iter.toList)
       }
     finally file.delete()
   }
@@ -41,9 +42,8 @@ class FastqParserTest extends FunSuite:
     val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
     try
       file.overwrite(data)
-      val fqp = new FastqParser(file.path)
       intercept[InvalidFileException] {
-        fqp.toList
+        Using.resource(new FastqParser(file.path).iterator)(iter => iter.toList)
       }
     finally file.delete()
   }
@@ -61,10 +61,7 @@ class FastqParserTest extends FunSuite:
     val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
     try
       file.overwrite(data)
-      val fqp = new FastqParser(file.path)
-      val fqi = fqp.iterator
-      assertEquals(fqi.toList.length, 2)
-      fqi.close()
+      Using.resource(new FastqParser(file.path).iterator)(iter => assertEquals(iter.toList.length, 2))
     finally file.delete()
   }
 
@@ -73,9 +70,8 @@ class FastqParserTest extends FunSuite:
     val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
     try
       file.overwrite(data)
-      val fqp = new FastqParser(file.path)
       intercept[InvalidFileException] {
-        fqp.toList
+        Using.resource(new FastqParser(file.path).iterator)(iter => iter.toList)
       }
     finally file.delete()
   }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/parser/FastqParserTest.scala
@@ -6,12 +6,11 @@
 package org.broadinstitute.gpp.poolq3.parser
 
 import better.files.*
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
+import munit.FunSuite
 
-class FastqParserTest extends AnyFlatSpec:
+class FastqParserTest extends FunSuite:
 
-  "FastqParser" should "reject a malformed FASTQ file" in {
+  test("FastqParser should reject a malformed FASTQ file") {
     val data =
       """@HWUSI-EAS100R:6:23:398:3989#1
         |AACTCACG
@@ -31,7 +30,7 @@ class FastqParserTest extends AnyFlatSpec:
     finally file.delete()
   }
 
-  "FastqParser" should "reject a misaligned FASTQ file" in {
+  test("FastqParser should reject a misaligned FASTQ file") {
     val data =
       """+
         |4<<8-767
@@ -49,7 +48,7 @@ class FastqParserTest extends AnyFlatSpec:
     finally file.delete()
   }
 
-  it should "parse complete records" in {
+  test("should parse complete records") {
     val data =
       """@HWUSI-EAS100R:6:23:398:3989#1
         |AACTCACG
@@ -64,12 +63,12 @@ class FastqParserTest extends AnyFlatSpec:
       file.overwrite(data)
       val fqp = new FastqParser(file.path)
       val fqi = fqp.iterator
-      val _ = (fqi.toList should have).length(2)
+      assertEquals(fqi.toList.length, 2)
       fqi.close()
     finally file.delete()
   }
 
-  it should "reject a file ending with only 1 line" in {
+  test("should reject a file ending with only 1 line") {
     val data = "@HWUSI-EAS100R:6:23:398:3989#1"
     val file: File = File.newTemporaryFile("FastqParserTest", ".fastq")
     try

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/parser/ReferenceDataTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/parser/ReferenceDataTest.scala
@@ -7,38 +7,38 @@ package org.broadinstitute.gpp.poolq3.parser
 
 import java.io.{BufferedReader, StringReader}
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.TestResources
 import org.broadinstitute.gpp.poolq3.reports.PoolQ2Dialect
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class ReferenceDataTest extends AnyFlatSpec with TestResources:
+class ReferenceDataTest extends FunSuite with TestResources:
 
-  "truncateMapping" should "truncate the barcode in a mapping" in {
+  test("truncateMapping should truncate the barcode in a mapping") {
     val actual = ReferenceData.truncator(15)("AAAAACCCCCGGGGGTTTTT")
     val expected = "AAAAACCCCCGGGGG"
-    actual should be(expected)
+    assertEquals(actual, expected)
   }
 
-  "truncateMapping" should "not change the length if the original length is given" in {
+  test("truncateMapping should not change the length if the original length is given") {
     val bc = "AAAAACCCCCGGGGGTTTTT"
     val actual = ReferenceData.truncator(bc.length)(bc)
     val expected = bc
-    actual should be(expected)
+    assertEquals(actual, expected)
   }
 
-  "guessDelimiter" should "guess the correct delimiter" in {
+  test("guessDelimiter should guess the correct delimiter") {
     val source =
       s"""THIS IS A COLUMN\tTHisIS Another Column
          |AACGTGTA;TCCGTGATG\tThis is a condition
          |""".stripMargin
     val r = new BufferedReader(new StringReader(source))
-    ReferenceData.guessDelimiter(r) should be('\t')
+    assertEquals(ReferenceData.guessDelimiter(r), '\t')
   }
 
-  "ReferenceData" should "read a csv file with no header" in {
+  test("ReferenceData should read a csv file with no header") {
     val path = resourcePath("reference.csv")
-    ReferenceData(path).mappings should be(
+    assertEquals(
+      ReferenceData(path).mappings,
       Seq(
         ReferenceEntry("AAAAAAAAAA", "This is a simple barcode"),
         ReferenceEntry("AAAA;AAAAAT", "This barcode has a semicolon")
@@ -46,9 +46,10 @@ class ReferenceDataTest extends AnyFlatSpec with TestResources:
     )
   }
 
-  it should "read a csv with a header" in {
+  test("should read a csv with a header") {
     val path = resourcePath("reference_header.csv")
-    ReferenceData(path).mappings should be(
+    assertEquals(
+      ReferenceData(path).mappings,
       Seq(
         ReferenceEntry("AAAAAAAAAA", "This is a simple barcode"),
         ReferenceEntry("AAAA;AAAAAT", "This barcode has a semicolon")
@@ -56,9 +57,10 @@ class ReferenceDataTest extends AnyFlatSpec with TestResources:
     )
   }
 
-  it should "read a csv with empty fields in some rows" in {
+  test("should read a csv with empty fields in some rows") {
     val path = resourcePath("reference_header_empty_rows.csv")
-    ReferenceData(path).mappings should be(
+    assertEquals(
+      ReferenceData(path).mappings,
       Seq(
         ReferenceEntry("AAAAAAAAAA", "This is a simple barcode"),
         ReferenceEntry("AAAA;AAAAAT", "This barcode has a semicolon")
@@ -66,9 +68,10 @@ class ReferenceDataTest extends AnyFlatSpec with TestResources:
     )
   }
 
-  it should "read a tsv file with no header" in {
+  test("should read a tsv file with no header") {
     val path = resourcePath("reference.txt")
-    ReferenceData(path).mappings should be(
+    assertEquals(
+      ReferenceData(path).mappings,
       Seq(
         ReferenceEntry("AAAAAAAAAA", "This is a simple barcode"),
         ReferenceEntry("AAAA;AAAAAT", "This barcode has a semicolon")
@@ -76,9 +79,10 @@ class ReferenceDataTest extends AnyFlatSpec with TestResources:
     )
   }
 
-  it should "read a tsv file with a header" in {
+  test("should read a tsv file with a header") {
     val path = resourcePath("reference_header.txt")
-    ReferenceData(path).mappings should be(
+    assertEquals(
+      ReferenceData(path).mappings,
       Seq(
         ReferenceEntry("AAAAAAAAAA", "This is a simple barcode"),
         ReferenceEntry("AAAA;AAAAAT", "This barcode has a semicolon")
@@ -86,20 +90,21 @@ class ReferenceDataTest extends AnyFlatSpec with TestResources:
     )
   }
 
-  it should "read a CSV with empty IDs" in {
+  test("should read a CSV with empty IDs") {
     val path = resourcePath("reference_empty_id.csv")
     val rd1 = ReferenceData(path)
-    val _ = rd1.mappings should be(Seq(ReferenceEntry("TTGAACCG", "EMPTY"), ReferenceEntry("GGCTTGCG", "")))
+    assertEquals(rd1.mappings, Seq(ReferenceEntry("TTGAACCG", "EMPTY"), ReferenceEntry("GGCTTGCG", "")))
     val rd2 = rd1.forColumnBarcodes(PoolQ2Dialect)
-    rd2.mappings should be(
+    assertEquals(
+      rd2.mappings,
       Seq(ReferenceEntry("TTGAACCG", "EMPTY"), ReferenceEntry("GGCTTGCG", "Unlabeled Sample Barcodes"))
     )
   }
 
-  it should "reject a CSV with empty barcodes but non-empty ID" in {
+  test("should reject a CSV with empty barcodes but non-empty ID") {
     val path = resourcePath("reference_empty_barcode.csv")
     val e = intercept[InvalidFileException](ReferenceData(path))
-    e.msg.exists(_.contains("Here's an ID with no barcode!")) should be(true)
+    assert(e.msg.exists(_.contains("Here's an ID with no barcode!")))
   }
 
 end ReferenceDataTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/reference/ExactReferenceTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/reference/ExactReferenceTest.scala
@@ -5,41 +5,40 @@
  */
 package org.broadinstitute.gpp.poolq3.reference
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.barcode
 import org.broadinstitute.gpp.poolq3.parser.ReferenceEntry
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class ExactReferenceTest extends AnyFlatSpec:
+class ExactReferenceTest extends FunSuite with ScalaCheckSuite:
   val referenceGen: Gen[List[String]] = Gen.listOfN(1000, barcode)
 
-  "ExactReference" should "find matches for a given barcode" in {
+  test("ExactReference should find matches for a given barcode") {
     forAll(referenceGen) { (barcodes: List[String]) =>
       val reference = ExactReference(barcodes.map(b => ReferenceEntry(b, b)), identity, includeAmbiguous = false)
 
       barcodes.foreach { bc =>
-        val _ = reference.isDefined(bc) should be(true)
-        val _ = reference.find(bc) should be(Seq(MatchedBarcode(bc, 0)))
-        reference.idsForBarcode(bc) should be(Seq(bc))
+        assert(reference.isDefined(bc))
+        assertEquals(reference.find(bc), Seq(MatchedBarcode(bc, 0)))
+        assertEquals(reference.idsForBarcode(bc), Seq(bc))
       }
 
-      val _ = reference.allIds.toSet should be(barcodes.toSet)
-      reference.allBarcodes.toSet should be(barcodes.toSet)
+      assertEquals(reference.allIds.toSet, barcodes.toSet)
+      assertEquals(reference.allBarcodes.toSet, barcodes.toSet)
     }
   }
 
-  it should "find variants with the correct distance" in {
+  test("should find variants with the correct distance") {
     val reference =
       ExactReference(Seq(ReferenceEntry("AAAAAAAAAAAAAAAAAAAA", "One")), identity, includeAmbiguous = false)
-    val _ = reference.find("AAAAAAAAAAAAAAAAAAAA") should be(Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 0)))
-    val _ = reference.find("NAAAAAAAAAAAAAAAAAAA") should be(Seq())
-    val _ = reference.find("AAAAAAAAAAAAAAAAAAAT") should be(Seq())
-    val _ = reference.find("NAAAAAAAAAAAAAAAAAAT") should be(Seq())
+    assertEquals(reference.find("AAAAAAAAAAAAAAAAAAAA"), Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 0)))
+    assertEquals(reference.find("NAAAAAAAAAAAAAAAAAAA"), Seq())
+    assertEquals(reference.find("AAAAAAAAAAAAAAAAAAAT"), Seq())
+    assertEquals(reference.find("NAAAAAAAAAAAAAAAAAAT"), Seq())
 
-    val _ = reference.barcodesForId("One") should be(Seq("AAAAAAAAAAAAAAAAAAAA"))
-    reference.idsForBarcode("AAAAAAAAAAAAAAAAAAAA") should be(Seq("One"))
+    assertEquals(reference.barcodesForId("One"), Seq("AAAAAAAAAAAAAAAAAAAA"))
+    assertEquals(reference.idsForBarcode("AAAAAAAAAAAAAAAAAAAA"), Seq("One"))
   }
 
 end ExactReferenceTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/reference/VariantReferenceTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/reference/VariantReferenceTest.scala
@@ -7,71 +7,76 @@ package org.broadinstitute.gpp.poolq3.reference
 
 import scala.util.Random
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.barcode
 import org.broadinstitute.gpp.poolq3.parser.ReferenceEntry
 import org.broadinstitute.gpp.poolq3.tools.withNs
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class VariantReferenceTest extends AnyFlatSpec:
+class VariantReferenceTest extends FunSuite with ScalaCheckSuite:
 
   private val referenceGen: Gen[List[String]] = Gen.listOfN(1000, barcode)
 
-  "VariantReference" should "find matches for a given barcode" in {
+  test("VariantReference should find matches for a given barcode") {
     forAll(referenceGen) { (barcodes: List[String]) =>
       val reference = VariantReference(barcodes.map(b => ReferenceEntry(b, b)), identity, false)
 
-      barcodes.foreach(barcode => reference.find(barcode) should be(Seq(MatchedBarcode(barcode, 0))))
+      barcodes.foreach(barcode => assertEquals(reference.find(barcode), Seq(MatchedBarcode(barcode, 0))))
     }
   }
 
-  it should "find matches for barcodes with zero or one Ns" in {
+  test("should find matches for barcodes with zero or one Ns") {
     forAll(referenceGen) { (barcodes: List[String]) =>
       val reference = VariantReference(barcodes.map(b => ReferenceEntry(b, b)), identity, false)
 
       barcodes.foreach { barcode =>
         val bcN = withNs(barcode, 1)
         val bcNs = withNs(barcode, 2 + Random.nextInt(3))
-        val _ = reference.find(barcode) should be(Seq(MatchedBarcode(barcode, 0)))
-        val _ = reference.find(bcN) should be(Seq(MatchedBarcode(barcode, 1)))
-        reference.find(bcNs) should be(Seq())
+        assertEquals(reference.find(barcode), Seq(MatchedBarcode(barcode, 0)))
+        assertEquals(reference.find(bcN), Seq(MatchedBarcode(barcode, 1)))
+        assertEquals(reference.find(bcNs), Seq())
       }
     }
   }
 
-  it should "find variants with the correct distance" in {
+  test("should find variants with the correct distance") {
     val reference =
       VariantReference(Seq(ReferenceEntry("AAAAAAAAAAAAAAAAAAAA", "One")), identity, includeAmbiguous = false)
-    val _ = reference.find("AAAAAAAAAAAAAAAAAAAA") should be(Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 0)))
-    val _ = reference.find("NAAAAAAAAAAAAAAAAAAA") should be(Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 1)))
-    val _ = reference.find("AAAAAAAAAAAAAAAAAAAT") should be(Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 1)))
-    reference.find("NAAAAAAAAAAAAAAAAAAT") should be(Seq())
+    assertEquals(reference.find("AAAAAAAAAAAAAAAAAAAA"), Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 0)))
+    assertEquals(reference.find("NAAAAAAAAAAAAAAAAAAA"), Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 1)))
+    assertEquals(reference.find("AAAAAAAAAAAAAAAAAAAT"), Seq(MatchedBarcode("AAAAAAAAAAAAAAAAAAAA", 1)))
+    assertEquals(reference.find("NAAAAAAAAAAAAAAAAAAT"), Seq())
   }
 
-  it should "handle truncated barcodes without Ns" in {
+  test("should handle truncated barcodes without Ns") {
     implicit val ord: Ordering[MatchedBarcode] = Ordering.by(mb => (mb.barcode, mb.distance))
 
     val barcodes = Seq(ReferenceEntry("AAAAAAAAAAAAAAAAAAAA", "One"), ReferenceEntry("AAAAAAAAAAAAAAAAAAAT", "Two"))
 
     val reference1 = VariantReference(barcodes, _.dropRight(1), includeAmbiguous = false)
-    val _ = reference1.find("AAAAAAAAAAAAAAAAAAA") should be(Seq())
+    assertEquals(reference1.find("AAAAAAAAAAAAAAAAAAA"), Seq())
 
     val reference2 = VariantReference(barcodes, _.dropRight(1), includeAmbiguous = true)
-    reference2.find("AAAAAAAAAAAAAAAAAAA").sorted should be(barcodes.map(bc => MatchedBarcode(bc.dnaBarcode, 0)).sorted)
+    assertEquals(
+      reference2.find("AAAAAAAAAAAAAAAAAAA").sorted,
+      barcodes.map(bc => MatchedBarcode(bc.dnaBarcode, 0)).sorted
+    )
   }
 
-  it should "handle truncated barcodes with Ns" in {
+  test("should handle truncated barcodes with Ns") {
     implicit val ord: Ordering[MatchedBarcode] = Ordering.by(mb => (mb.barcode, mb.distance))
 
     val barcodes = Seq(ReferenceEntry("AAAAAAAAAAAAAAAAAAAA", "One"), ReferenceEntry("AAAAAAAAAAAAAAAAAATA", "Two"))
 
     val reference1 = VariantReference(barcodes, _.dropRight(1), includeAmbiguous = false)
-    val _ = reference1.find("AAAAAAAAAAAAAAAAAAN") should be(Seq())
+    assertEquals(reference1.find("AAAAAAAAAAAAAAAAAAN"), Seq())
 
     val reference2 = VariantReference(barcodes, _.dropRight(1), includeAmbiguous = true)
-    reference2.find("AAAAAAAAAAAAAAAAAAN").sorted should be(barcodes.map(bc => MatchedBarcode(bc.dnaBarcode, 1)).sorted)
+    assertEquals(
+      reference2.find("AAAAAAAAAAAAAAAAAAN").sorted,
+      barcodes.map(bc => MatchedBarcode(bc.dnaBarcode, 1)).sorted
+    )
   }
 
 end VariantReferenceTest

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/reports/CorrelationFileTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/reports/CorrelationFileTest.scala
@@ -113,11 +113,12 @@ class CorrelationFileTest extends FunSuite:
 
       val normalizedCounts = LogNormalizedCountsWriter.logNormalizedCounts(state.known, rowReference, singleCondRef)
 
-      // we've set a trap - if we try to compute a correlation, the library code should throw an exception
+      // we've set a trap - if we try to compute a correlation, the math library would throw an exception; this test verifies that
+      // instead, we catch that and just don't write anything to the file
       val _ = CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
 
       // be sure also that we didn't actually write anything to the file
-      Using(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
+      Using.resource(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
 
     finally
       val _ = Files.deleteIfExists(outputFile)
@@ -142,11 +143,12 @@ class CorrelationFileTest extends FunSuite:
 
       val normalizedCounts = LogNormalizedCountsWriter.logNormalizedCounts(state.known, rowReference, singleCondRef)
 
-      // we've set a trap - if we try to compute a correlation, the library code should throw an exception
+      // we've set a trap - if we try to compute a correlation, the math library would throw an exception; this test verifies that
+      // instead, we catch that and just don't write anything to the file
       val _ = CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
 
       // be sure also that we didn't actually write anything to the file
-      Using(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
+      Using.resource(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
 
     finally
       val _ = Files.deleteIfExists(outputFile)

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/reports/CorrelationFileTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/reports/CorrelationFileTest.scala
@@ -10,15 +10,14 @@ import java.nio.file.Files
 import scala.io.Source
 import scala.util.{Random, Using}
 
+import munit.FunSuite
 import org.broadinstitute.gpp.poolq3.PoolQ
 import org.broadinstitute.gpp.poolq3.barcode.{Barcodes, FoundBarcode}
 import org.broadinstitute.gpp.poolq3.parser.{CloseableIterable, ReferenceEntry}
 import org.broadinstitute.gpp.poolq3.process.ScoringConsumer
 import org.broadinstitute.gpp.poolq3.reference.ExactReference
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
 
-class CorrelationFileTest extends AnyFlatSpec:
+class CorrelationFileTest extends FunSuite:
 
   private val Condition1 = "DMSO"
   private val Condition2 = "ITMFA"
@@ -71,7 +70,7 @@ class CorrelationFileTest extends AnyFlatSpec:
     Barcodes(Some(FoundBarcode(row.toCharArray, 0)), None, Some(FoundBarcode(col.toCharArray, 0)), None)
   })
 
-  "CorrelationFileWriter" should "write a correct correlation file" in {
+  test("CorrelationFileWriter should write a correct correlation file") {
     val outputFile = Files.createTempFile("correlation-file-test", ".txt")
     try
       val consumer = new ScoringConsumer(rowReference, colReference, countAmbiguous = true, false, None, None, false)
@@ -91,14 +90,14 @@ class CorrelationFileTest extends AnyFlatSpec:
 
       Using.resource(Source.fromFile(outputFile.toFile)) { contents =>
         // now check the contents
-        contents.mkString should be(expected)
+        assertEquals(contents.mkString, expected)
       }
     finally
       val _ = Files.deleteIfExists(outputFile)
     end try
   }
 
-  it should "not write a correlation file for a run with a single condition" in {
+  test("should not write a correlation file for a run with a single condition") {
     val singleCondRef =
       ExactReference(
         List(ReferenceEntry(SampleBarcode1, Condition1), ReferenceEntry(SampleBarcode2, Condition1)),
@@ -115,19 +114,17 @@ class CorrelationFileTest extends AnyFlatSpec:
       val normalizedCounts = LogNormalizedCountsWriter.logNormalizedCounts(state.known, rowReference, singleCondRef)
 
       // we've set a trap - if we try to compute a correlation, the library code should throw an exception
-      val _ = noException should be thrownBy {
-        CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
-      }
+      val _ = CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
 
       // be sure also that we didn't actually write anything to the file
-      Using(Source.fromFile(outputFile.toFile))(src => src.getLines().mkString("\n") should be(""))
+      Using(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
 
     finally
       val _ = Files.deleteIfExists(outputFile)
     end try
   }
 
-  it should "not write a correlation file for a run with a single row barcode" in {
+  test("should not write a correlation file for a run with a single row barcode") {
     val rowReference =
       ExactReference(Constructs.take(1).map(b => ReferenceEntry(b, b)), identity, includeAmbiguous = false)
     val singleCondRef =
@@ -146,12 +143,10 @@ class CorrelationFileTest extends AnyFlatSpec:
       val normalizedCounts = LogNormalizedCountsWriter.logNormalizedCounts(state.known, rowReference, singleCondRef)
 
       // we've set a trap - if we try to compute a correlation, the library code should throw an exception
-      val _ = noException should be thrownBy {
-        CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
-      }
+      val _ = CorrelationFileWriter.write(outputFile, normalizedCounts, rowReference, singleCondRef)
 
       // be sure also that we didn't actually write anything to the file
-      Using(Source.fromFile(outputFile.toFile))(src => src.getLines().mkString("\n") should be(""))
+      Using(Source.fromFile(outputFile.toFile))(src => assertEquals(src.getLines().mkString("\n"), ""))
 
     finally
       val _ = Files.deleteIfExists(outputFile)

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/seq/SeqPackageTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/seq/SeqPackageTest.scala
@@ -5,87 +5,86 @@
  */
 package org.broadinstitute.gpp.poolq3.seq
 
+import munit.{FunSuite, ScalaCheckSuite}
 import org.broadinstitute.gpp.poolq3.gen.{acgtn, barcode, dnaSeq, nonEmptyDnaSeq}
 import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.*
+import org.scalacheck.Prop.forAll
 
-class SeqPackageTest extends AnyFlatSpec:
+class SeqPackageTest extends FunSuite with ScalaCheckSuite:
 
-  "complement" should "complement a string of DNA" in {
-    val _ = complement("") should be("")
-    val _ = complement("ACGT") should be("TGCA")
-    complement("NAATTTG") should be("NTTAAAC")
+  test("complement should complement a string of DNA") {
+    assertEquals(complement(""), "")
+    assertEquals(complement("ACGT"), "TGCA")
+    assertEquals(complement("NAATTTG"), "NTTAAAC")
   }
 
-  "complement" should "roundtrip arbitrary DNA" in {
-    forAll(barcode)(b => complement(complement(b)) should be(b))
+  test("complement should roundtrip arbitrary DNA") {
+    forAll(barcode)(b => assertEquals(complement(complement(b)), b))
   }
 
-  "reverseComplement" should "reverse complement a string of DNA" in {
-    val _ = reverseComplement("") should be("")
-    val _ = reverseComplement("ACGT") should be("ACGT")
-    reverseComplement("NTTGTATTTA") should be("TAAATACAAN")
+  test("reverseComplement should reverse complement a string of DNA") {
+    assertEquals(reverseComplement(""), "")
+    assertEquals(reverseComplement("ACGT"), "ACGT")
+    assertEquals(reverseComplement("NTTGTATTTA"), "TAAATACAAN")
   }
 
-  "reverseComplement" should "roundtrip arbitrary DNA" in {
-    forAll(barcode)(b => reverseComplement(reverseComplement(b)) should be(b))
+  test("reverseComplement should roundtrip arbitrary DNA") {
+    forAll(barcode)(b => assertEquals(reverseComplement(reverseComplement(b)), b))
   }
 
-  "ndist" should "always be >= 0" in {
-    forAll(barcode, barcode)((x, y) => countMismatches(x, y) should be >= 0)
+  test("ndist should always be >= 0") {
+    forAll(barcode, barcode)((x, y) => assert(countMismatches(x, y) >= 0))
   }
 
-  it should "be 0 iff and only iff x = y" in {
+  test("should be 0 iff and only iff x = y") {
     forAll(barcode, barcode) { (x, y) =>
       val xydist = countMismatches(x, y)
       if x != y then
-        val _ = xydist should be > 0
-        val _ = countMismatches(x, x) should be(0)
-        countMismatches(y, y) should be(0)
-      else xydist should be(0)
+        assert(xydist > 0)
+        assertEquals(countMismatches(x, x), 0)
+        assertEquals(countMismatches(y, y), 0)
+      else assertEquals(xydist, 0)
     }
   }
 
-  it should "be symmetric" in {
-    forAll(barcode, barcode)((x, y) => countMismatches(x, y) should be(countMismatches(y, x)))
+  test("should be symmetric") {
+    forAll(barcode, barcode)((x, y) => assertEquals(countMismatches(x, y), countMismatches(y, x)))
   }
 
-  it should "satisfy the triangle inequality in our domain" in {
+  test("should satisfy the triangle inequality in our domain") {
     forAll(barcode, barcode, barcode) { (x, y, z) =>
-      (countMismatches(x, y) + countMismatches(y, z)) should be >= countMismatches(x, z)
+      assert((countMismatches(x, y) + countMismatches(y, z)) >= countMismatches(x, z))
     }
   }
 
-  "isDna" should "return true for ACGTN bases" in {
-    forAll(nonEmptyDnaSeq(acgtn))(s => isDna(s) should be(true))
+  test("isDna should return true for ACGTN bases") {
+    forAll(nonEmptyDnaSeq(acgtn))(s => assert(isDna(s)))
   }
 
-  it should "return false for non ACGTN bases" in {
+  test("should return false for non ACGTN bases") {
     val nonDnaChar =
       Gen.choose(Char.MinValue, Char.MaxValue).suchThat {
         Set('A', 'C', 'G', 'T', 'N').contains(_) == false
       }
     forAll(nonEmptyDnaSeq(acgtn), nonEmptyDnaSeq(acgtn), nonDnaChar) { (s1, s2, c) =>
-      isDna(s1 + c.toString + s2) should be(false)
+      assert(!isDna(s1 + c.toString + s2))
     }
   }
 
-  "nCount" should "return at most max Ns" in {
-    val _ = nCount("AAANAN".toCharArray, 0) should be(1)
-    val _ = nCount("AAANAN".toCharArray, 1) should be(1)
-    val _ = nCount("AAANAN".toCharArray, 2) should be(2)
-    val _ = nCount("AAANAN".toCharArray, 3) should be(2)
-    nCount("TGNTA".toCharArray, 0) should be(1)
+  test("nCount should return at most max Ns") {
+    assertEquals(nCount("AAANAN".toCharArray, 0), 1)
+    assertEquals(nCount("AAANAN".toCharArray, 1), 1)
+    assertEquals(nCount("AAANAN".toCharArray, 2), 2)
+    assertEquals(nCount("AAANAN".toCharArray, 3), 2)
+    assertEquals(nCount("TGNTA".toCharArray, 0), 1)
   }
 
-  it should "handle random sequences" in {
+  test("should handle random sequences") {
     forAll(dnaSeq(acgtn)) { s =>
       val chars = s.toCharArray
       s.indices.foreach { idx =>
         // the min/max thing is to deal with weirdness if max is 0 - we have to find an N to exit early
-        nCount(chars, idx) should be(math.min(math.max(idx, 1), nCount(chars)))
+        assertEquals(nCount(chars, idx), math.min(math.max(idx, 1), nCount(chars)))
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/gpp/poolq3/seq/SeqPackageTest.scala
+++ b/src/test/scala/org/broadinstitute/gpp/poolq3/seq/SeqPackageTest.scala
@@ -36,7 +36,7 @@ class SeqPackageTest extends FunSuite with ScalaCheckSuite:
     forAll(barcode, barcode)((x, y) => assert(countMismatches(x, y) >= 0))
   }
 
-  test("should be 0 iff and only iff x = y") {
+  test("should be 0 iff x = y") {
     forAll(barcode, barcode) { (x, y) =>
       val xydist = countMismatches(x, y)
       if x != y then


### PR DESCRIPTION
Some carefully supervised AI updates to PoolQ (with some manual corrections)
• Fix a harmlessly incorrect log message
• Close a stream on completion (near the end of the program)
• Better handling of errors to avoid a potential deadlock in the unexpected sequence tracker
• Ported tests to munit
• Updated some test names and fixed some problematic ScalaCheck generators